### PR TITLE
Add Active Sessions and BDA login-approval flow

### DIFF
--- a/Controllers/CrmAuthController.js
+++ b/Controllers/CrmAuthController.js
@@ -1,9 +1,68 @@
 import crypto from 'crypto';
 import jwt from 'jsonwebtoken';
 import { CrmUserModel } from '../Schema_Models/CrmUser.js';
+import { CrmSessionModel } from '../Schema_Models/CrmSessionModel.js';
+import { CrmLoginApprovalModel } from '../Schema_Models/CrmLoginApprovalModel.js';
+import { CrmTrustedDeviceModel } from '../Schema_Models/CrmTrustedDeviceModel.js';
 import { sendCrmOtpEmail } from '../Utils/SendGridHelper.js';
 import { deleteOtp, decrementAttempts, getOtp, setOtp, getOtpCacheStats } from '../Utils/CrmOtpCache.js';
 import { getCrmJwtSecret } from '../Middlewares/CrmAuth.js';
+import { getClientIp, detectCountryFromIp } from '../Utils/GeoIP.js';
+import { parseUserAgent } from '../Utils/UserAgentParser.js';
+import { computeDeviceKey } from '../Utils/DeviceKey.js';
+
+/**
+ * Issues a CRM JWT + session record for a fully-authenticated user (OTP verified,
+ * and — for BDAs — device already trusted or just approved by an admin).
+ * Shared by the direct-login path and the "approval just granted" path so both
+ * produce an identical session record.
+ */
+export async function issueCrmSessionAndToken({ user, ip, countryCode, country, browser, os, deviceType, userAgent, rememberMe }) {
+  const expiresIn = rememberMe ? '30d' : '7d';
+  const expiresMs = rememberMe ? 30 * 24 * 60 * 60 * 1000 : 7 * 24 * 60 * 60 * 1000;
+  const sessionId = crypto.randomUUID();
+
+  const token = jwt.sign(
+    {
+      role: 'crm_user',
+      email: user.email,
+      name: user.name,
+      permissions: user.permissions || [],
+      sessionId,
+    },
+    getCrmJwtSecret(),
+    { expiresIn }
+  );
+
+  try {
+    await CrmSessionModel.create({
+      sessionId,
+      email: user.email,
+      ip: ip || '',
+      countryCode,
+      country,
+      browser,
+      os,
+      deviceType,
+      userAgent: userAgent || '',
+      lastSeenAt: new Date(),
+      expiresAt: new Date(Date.now() + expiresMs),
+    });
+  } catch (sessionError) {
+    // Session bookkeeping must never block a successful login.
+    console.error('CRM session creation error:', sessionError?.message || sessionError);
+  }
+
+  return {
+    token,
+    user: {
+      email: user.email,
+      name: user.name,
+      permissions: user.permissions || [],
+      role: user.role || 'bda',
+    },
+  };
+}
 
 function normalizeEmail(email) {
   return String(email || '').trim().toLowerCase();
@@ -90,31 +149,91 @@ export async function verifyCrmOtp(req, res) {
       return res.status(403).json({ success: false, error: 'User not authorized' });
     }
 
-    const expiresIn = rememberMe ? '30d' : '7d';
+    const ip = getClientIp(req);
+    const { countryCode, country } = detectCountryFromIp(ip);
+    const { browser, os, deviceType } = parseUserAgent(req.headers['user-agent']);
+    const userAgent = req.headers['user-agent'] || '';
 
-    const token = jwt.sign(
-      {
-        role: 'crm_user',
-        email: user.email,
-        name: user.name,
-        permissions: user.permissions || [],
-      },
-      getCrmJwtSecret(),
-      { expiresIn }
-    );
+    // Admins bypass the device-approval gate entirely; only BDAs are gated.
+    if (user.role === 'bda') {
+      const deviceKey = computeDeviceKey(userAgent, ip);
+      const trusted = await CrmTrustedDeviceModel.findOne({ email: user.email, deviceKey }).lean();
 
-    return res.status(200).json({
-      success: true,
-      token,
-      user: {
-        email: user.email,
-        name: user.name,
-        permissions: user.permissions || [],
-        role: user.role || 'bda',
-      },
+      if (!trusted) {
+        const sessionId = crypto.randomUUID();
+        await CrmLoginApprovalModel.create({
+          email: user.email,
+          name: user.name,
+          deviceKey,
+          sessionId,
+          ip: ip || '',
+          countryCode,
+          country,
+          browser,
+          os,
+          deviceType,
+          userAgent,
+          status: 'pending',
+          expiresIn: rememberMe ? '30d' : '7d',
+        });
+
+        return res.status(200).json({
+          success: true,
+          pendingApproval: true,
+          approvalId: sessionId,
+          message: 'New device detected. Waiting for admin approval.',
+        });
+      }
+    }
+
+    const result = await issueCrmSessionAndToken({
+      user, ip, countryCode, country, browser, os, deviceType, userAgent, rememberMe,
     });
+
+    return res.status(200).json({ success: true, ...result });
   } catch (error) {
     console.error('CRM OTP verify error:', error?.message || error);
+    return res.status(500).json({ success: false, error: 'Server error' });
+  }
+}
+
+export async function getLoginApprovalStatus(req, res) {
+  try {
+    const { approvalId } = req.params;
+    const approval = await CrmLoginApprovalModel.findOne({ sessionId: approvalId });
+    if (!approval) return res.status(404).json({ success: false, error: 'Approval request not found' });
+
+    if (approval.status === 'pending') {
+      return res.status(200).json({ success: true, status: 'pending' });
+    }
+
+    if (approval.status === 'denied') {
+      return res.status(200).json({ success: true, status: 'denied' });
+    }
+
+    // approved — but only hand out the token once; approval doc is consumed on first poll hit.
+    if (approval.status === 'approved' && approval.issuedToken) {
+      const token = approval.issuedToken;
+      approval.issuedToken = undefined;
+      await approval.save();
+
+      const user = await CrmUserModel.findOne({ email: approval.email }).lean();
+      return res.status(200).json({
+        success: true,
+        status: 'approved',
+        token,
+        user: {
+          email: user.email,
+          name: user.name,
+          permissions: user.permissions || [],
+          role: user.role || 'bda',
+        },
+      });
+    }
+
+    return res.status(200).json({ success: true, status: 'approved' });
+  } catch (error) {
+    console.error('CRM login approval status error:', error?.message || error);
     return res.status(500).json({ success: false, error: 'Server error' });
   }
 }

--- a/Controllers/CrmLoginApprovalController.js
+++ b/Controllers/CrmLoginApprovalController.js
@@ -1,0 +1,110 @@
+import { CrmLoginApprovalModel } from "../Schema_Models/CrmLoginApprovalModel.js";
+import { CrmTrustedDeviceModel } from "../Schema_Models/CrmTrustedDeviceModel.js";
+import { CrmUserModel } from "../Schema_Models/CrmUser.js";
+import { issueCrmSessionAndToken } from "./CrmAuthController.js";
+
+function toApprovalView(doc) {
+  return {
+    id: String(doc._id),
+    approvalId: doc.sessionId,
+    email: doc.email,
+    name: doc.name,
+    ip: doc.ip || "",
+    country: doc.country || "",
+    countryCode: doc.countryCode || "",
+    deviceLabel: `${doc.browser || "Unknown"} on ${doc.os || "Unknown"}`,
+    browser: doc.browser || "",
+    os: doc.os || "",
+    deviceType: doc.deviceType || "",
+    status: doc.status,
+    createdAt: doc.createdAt,
+  };
+}
+
+export const listPendingLoginApprovals = async (req, res) => {
+  try {
+    const docs = await CrmLoginApprovalModel.find({ status: "pending" }).sort({ createdAt: -1 }).limit(100);
+    return res.status(200).json({ success: true, data: docs.map(toApprovalView) });
+  } catch (error) {
+    console.error("Error listing login approvals:", error);
+    return res.status(500).json({ success: false, error: error.message || "Failed to list approvals" });
+  }
+};
+
+export const approveLoginApproval = async (req, res) => {
+  try {
+    const { approvalId } = req.params;
+    const approval = await CrmLoginApprovalModel.findOne({ sessionId: approvalId });
+    if (!approval) return res.status(404).json({ success: false, error: "Approval request not found" });
+    if (approval.status !== "pending") {
+      return res.status(409).json({ success: false, error: `Already ${approval.status}` });
+    }
+
+    const user = await CrmUserModel.findOne({ email: approval.email }).lean();
+    if (!user || user.isActive === false) {
+      approval.status = "denied";
+      approval.resolvedAt = new Date();
+      approval.resolvedBy = req.crmAdmin?.email || "admin";
+      await approval.save();
+      return res.status(404).json({ success: false, error: "User no longer active" });
+    }
+
+    // Remember this device so future logins from it skip approval.
+    await CrmTrustedDeviceModel.findOneAndUpdate(
+      { email: approval.email, deviceKey: approval.deviceKey },
+      {
+        email: approval.email,
+        deviceKey: approval.deviceKey,
+        browser: approval.browser,
+        os: approval.os,
+        approvedBy: req.crmAdmin?.email || "admin",
+        approvedAt: new Date(),
+      },
+      { upsert: true }
+    );
+
+    const { token } = await issueCrmSessionAndToken({
+      user,
+      ip: approval.ip,
+      countryCode: approval.countryCode,
+      country: approval.country,
+      browser: approval.browser,
+      os: approval.os,
+      deviceType: approval.deviceType,
+      userAgent: approval.userAgent,
+      rememberMe: approval.expiresIn === "30d",
+    });
+
+    approval.status = "approved";
+    approval.resolvedAt = new Date();
+    approval.resolvedBy = req.crmAdmin?.email || "admin";
+    approval.issuedToken = token;
+    await approval.save();
+
+    return res.status(200).json({ success: true });
+  } catch (error) {
+    console.error("Error approving login:", error);
+    return res.status(500).json({ success: false, error: error.message || "Failed to approve login" });
+  }
+};
+
+export const denyLoginApproval = async (req, res) => {
+  try {
+    const { approvalId } = req.params;
+    const approval = await CrmLoginApprovalModel.findOne({ sessionId: approvalId });
+    if (!approval) return res.status(404).json({ success: false, error: "Approval request not found" });
+    if (approval.status !== "pending") {
+      return res.status(409).json({ success: false, error: `Already ${approval.status}` });
+    }
+
+    approval.status = "denied";
+    approval.resolvedAt = new Date();
+    approval.resolvedBy = req.crmAdmin?.email || "admin";
+    await approval.save();
+
+    return res.status(200).json({ success: true });
+  } catch (error) {
+    console.error("Error denying login:", error);
+    return res.status(500).json({ success: false, error: error.message || "Failed to deny login" });
+  }
+};

--- a/Controllers/CrmSessionController.js
+++ b/Controllers/CrmSessionController.js
@@ -1,0 +1,84 @@
+import { CrmSessionModel } from "../Schema_Models/CrmSessionModel.js";
+
+function toSessionView(doc, currentSessionId) {
+  return {
+    id: String(doc._id),
+    sessionId: doc.sessionId,
+    email: doc.email,
+    ip: doc.ip || "",
+    country: doc.country || "",
+    countryCode: doc.countryCode || "",
+    deviceLabel: `${doc.browser || "Unknown"} on ${doc.os || "Unknown"}`,
+    browser: doc.browser || "",
+    os: doc.os || "",
+    deviceType: doc.deviceType || "",
+    revoked: doc.revoked,
+    createdAt: doc.createdAt,
+    lastSeenAt: doc.lastSeenAt,
+    isCurrent: doc.sessionId === currentSessionId,
+  };
+}
+
+// Sessions for the logged-in user only.
+export const listMySessions = async (req, res) => {
+  try {
+    const email = req.crmUser?.email;
+    const currentSessionId = req.crmUser?.sessionId;
+    const docs = await CrmSessionModel.find({ email, revoked: false })
+      .sort({ lastSeenAt: -1 });
+    return res.status(200).json({ success: true, data: docs.map((d) => toSessionView(d, currentSessionId)) });
+  } catch (error) {
+    console.error("Error listing sessions:", error);
+    return res.status(500).json({ success: false, error: error.message || "Failed to list sessions" });
+  }
+};
+
+// Revoke a session — must belong to the requesting user (or requester is admin).
+export const revokeMySession = async (req, res) => {
+  try {
+    const { sessionId } = req.params;
+    const email = req.crmUser?.email;
+
+    const doc = await CrmSessionModel.findOne({ sessionId });
+    if (!doc) return res.status(404).json({ success: false, error: "Session not found" });
+    if (doc.email !== email) return res.status(403).json({ success: false, error: "Forbidden" });
+
+    doc.revoked = true;
+    doc.revokedAt = new Date();
+    await doc.save();
+
+    return res.status(200).json({ success: true });
+  } catch (error) {
+    console.error("Error revoking session:", error);
+    return res.status(500).json({ success: false, error: error.message || "Failed to revoke session" });
+  }
+};
+
+// Admin: list every active session across all CRM users.
+export const listAllSessions = async (req, res) => {
+  try {
+    const docs = await CrmSessionModel.find({ revoked: false }).sort({ lastSeenAt: -1 });
+    return res.status(200).json({ success: true, data: docs.map((d) => toSessionView(d, null)) });
+  } catch (error) {
+    console.error("Error listing all sessions:", error);
+    return res.status(500).json({ success: false, error: error.message || "Failed to list sessions" });
+  }
+};
+
+// Admin: revoke any user's session.
+export const adminRevokeSession = async (req, res) => {
+  try {
+    const { sessionId } = req.params;
+    const doc = await CrmSessionModel.findOne({ sessionId });
+    if (!doc) return res.status(404).json({ success: false, error: "Session not found" });
+
+    doc.revoked = true;
+    doc.revokedAt = new Date();
+    await doc.save();
+
+    return res.status(200).json({ success: true });
+  } catch (error) {
+    console.error("Error revoking session (admin):", error);
+    return res.status(500).json({ success: false, error: error.message || "Failed to revoke session" });
+  }
+};

--- a/Middlewares/CrmAuth.js
+++ b/Middlewares/CrmAuth.js
@@ -1,4 +1,5 @@
 import jwt from 'jsonwebtoken';
+import { CrmSessionModel } from '../Schema_Models/CrmSessionModel.js';
 
 export function getCrmJwtSecret() {
   // Prefer a dedicated secret; fall back to existing long-lived secret in this repo if present.
@@ -32,7 +33,7 @@ export function requireCrmAdmin(req, res, next) {
   }
 }
 
-export function requireCrmUser(req, res, next) {
+export async function requireCrmUser(req, res, next) {
   try {
     const token = readBearerToken(req);
     if (!token) return res.status(401).json({ success: false, error: 'Missing Authorization bearer token' });
@@ -40,6 +41,20 @@ export function requireCrmUser(req, res, next) {
     if (payload?.role !== 'crm_user') {
       return res.status(403).json({ success: false, error: 'Forbidden' });
     }
+
+    // Tokens issued before session tracking was added have no sessionId — let them through
+    // unchecked rather than force-logging-out everyone on deploy.
+    if (payload.sessionId) {
+      const session = await CrmSessionModel.findOneAndUpdate(
+        { sessionId: payload.sessionId },
+        { lastSeenAt: new Date() },
+        { new: true }
+      );
+      if (session && session.revoked) {
+        return res.status(401).json({ success: false, error: 'Session revoked. Please log in again.' });
+      }
+    }
+
     req.crmUser = payload;
     return next();
   } catch (error) {

--- a/Routes.js
+++ b/Routes.js
@@ -153,6 +153,7 @@ import { getActivityLogs, getActivityFilters } from './Controllers/ActivityLogCo
 import { getPaidClientsAnalytics } from './Controllers/PaidClientsController.js';
 import { getStripePaymentsByMonth, getStripeAllMonthsSummary } from './Controllers/StripeDataController.js';
 import { getManualPaymentsByMonth, createManualPayment, updateManualPayment, deleteManualPayment } from './Controllers/ManualPaymentController.js';
+import { listMySessions, revokeMySession, listAllSessions, adminRevokeSession } from './Controllers/CrmSessionController.js';
 import {
   listDesignedTemplates,
   getDesignedTemplate,
@@ -174,7 +175,8 @@ import {
   getLiveCallForLead,
   getAgentPresence,
 } from './Controllers/ZoomPhoneController.js';
-import { requestCrmOtp, verifyCrmOtp, crmMe } from './Controllers/CrmAuthController.js';
+import { requestCrmOtp, verifyCrmOtp, crmMe, getLoginApprovalStatus } from './Controllers/CrmAuthController.js';
+import { listPendingLoginApprovals, approveLoginApproval, denyLoginApproval } from './Controllers/CrmLoginApprovalController.js';
 import { requireCrmAdmin, requireCrmUser, requireCrmPermission, requireCrmAnyPermission, requireCrmEdit } from './Middlewares/CrmAuth.js';
 import {
   getAvailableLeads,
@@ -296,7 +298,19 @@ export default function Routes(app) {
   app.post('/api/crm/auth/request-otp', requestCrmOtp);
   app.post('/api/crm/auth/verify-otp', verifyCrmOtp);
   app.get('/api/crm/auth/me', requireCrmUser, crmMe);
-  
+  app.get('/api/crm/auth/login-approval/:approvalId/status', getLoginApprovalStatus);
+
+  // BDA login approval — admin reviews new-device login attempts before the BDA can sign in.
+  app.get('/api/crm/admin/login-approvals', requireCrmAdmin, listPendingLoginApprovals);
+  app.post('/api/crm/admin/login-approvals/:approvalId/approve', requireCrmAdmin, approveLoginApproval);
+  app.post('/api/crm/admin/login-approvals/:approvalId/deny', requireCrmAdmin, denyLoginApproval);
+
+  // Active Sessions — device/IP/location tracking for CRM logins.
+  app.get('/api/crm/sessions', requireCrmUser, listMySessions);
+  app.post('/api/crm/sessions/:sessionId/revoke', requireCrmUser, revokeMySession);
+  app.get('/api/crm/admin/sessions', requireCrmAdmin, listAllSessions);
+  app.post('/api/crm/admin/sessions/:sessionId/revoke', requireCrmAdmin, adminRevokeSession);
+
   app.get('/api/bda/available-leads', requireCrmUser, getAvailableLeads);
   app.get('/api/bda/lead-by-email/:email', requireCrmUser, getLeadByEmail);
   app.post('/api/bda/claim-lead/:bookingId', requireCrmUser, requireCrmEdit('claim_leads'), claimLead);

--- a/Schema_Models/CrmLoginApprovalModel.js
+++ b/Schema_Models/CrmLoginApprovalModel.js
@@ -1,0 +1,25 @@
+import mongoose from 'mongoose';
+
+// Tracks a BDA login attempt from an unrecognized device, pending admin approval.
+// Once approved, the deviceKey is remembered on CrmUserModel-adjacent trusted-device
+// list so future logins from the same device/browser skip this gate.
+const CrmLoginApprovalSchema = new mongoose.Schema({
+  email: { type: String, required: true, index: true },
+  name: { type: String },
+  deviceKey: { type: String, required: true },
+  sessionId: { type: String, required: true, unique: true },
+  ip: { type: String },
+  countryCode: { type: String },
+  country: { type: String },
+  browser: { type: String },
+  os: { type: String },
+  deviceType: { type: String },
+  userAgent: { type: String },
+  status: { type: String, enum: ['pending', 'approved', 'denied'], default: 'pending', index: true },
+  resolvedBy: { type: String },
+  resolvedAt: { type: Date },
+  expiresIn: { type: String }, // '7d' | '30d' — remembered so approval can issue the right-lived JWT
+  issuedToken: { type: String }, // set once approved; cleared after the BDA's poll picks it up
+}, { timestamps: true });
+
+export const CrmLoginApprovalModel = mongoose.model('CrmLoginApproval', CrmLoginApprovalSchema);

--- a/Schema_Models/CrmSessionModel.js
+++ b/Schema_Models/CrmSessionModel.js
@@ -1,0 +1,19 @@
+import mongoose from 'mongoose';
+
+const CrmSessionSchema = new mongoose.Schema({
+  sessionId: { type: String, required: true, unique: true, index: true },
+  email: { type: String, required: true, index: true },
+  ip: { type: String },
+  countryCode: { type: String },
+  country: { type: String },
+  browser: { type: String },
+  os: { type: String },
+  deviceType: { type: String },
+  userAgent: { type: String },
+  revoked: { type: Boolean, default: false },
+  revokedAt: { type: Date },
+  lastSeenAt: { type: Date, default: Date.now },
+  expiresAt: { type: Date, required: true },
+}, { timestamps: true });
+
+export const CrmSessionModel = mongoose.model('CrmSession', CrmSessionSchema);

--- a/Schema_Models/CrmTrustedDeviceModel.js
+++ b/Schema_Models/CrmTrustedDeviceModel.js
@@ -1,0 +1,16 @@
+import mongoose from 'mongoose';
+
+// A device/browser combination that an admin has already approved for a given
+// BDA email. Future logins matching the same (email, deviceKey) skip approval.
+const CrmTrustedDeviceSchema = new mongoose.Schema({
+  email: { type: String, required: true, index: true },
+  deviceKey: { type: String, required: true },
+  browser: { type: String },
+  os: { type: String },
+  approvedBy: { type: String },
+  approvedAt: { type: Date, default: Date.now },
+}, { timestamps: true });
+
+CrmTrustedDeviceSchema.index({ email: 1, deviceKey: 1 }, { unique: true });
+
+export const CrmTrustedDeviceModel = mongoose.model('CrmTrustedDevice', CrmTrustedDeviceSchema);

--- a/Utils/DeviceKey.js
+++ b/Utils/DeviceKey.js
@@ -1,0 +1,9 @@
+import crypto from 'crypto';
+
+// A stable fingerprint for "this browser on this network," built from User-Agent + IP.
+// Deliberately coarse: switching networks (e.g. wifi -> mobile data) or browsers counts
+// as a new device and re-triggers approval, which is the safer default for this use case.
+export function computeDeviceKey(userAgent, ip) {
+  const value = `${String(userAgent || '').trim()}|${String(ip || '').trim()}`;
+  return crypto.createHash('sha256').update(value).digest('hex');
+}

--- a/Utils/UserAgentParser.js
+++ b/Utils/UserAgentParser.js
@@ -1,0 +1,31 @@
+// Minimal dependency-free User-Agent parser covering the common browsers/OSes.
+// Good enough for "which device/browser is this session on" display purposes —
+// not meant to be as exhaustive as ua-parser-js.
+
+export function parseUserAgent(uaString) {
+  const ua = String(uaString || '');
+
+  let os = 'Unknown OS';
+  if (/windows nt/i.test(ua)) os = 'Windows';
+  else if (/iphone|ipad|ipod/i.test(ua)) os = 'iOS';
+  else if (/mac os x/i.test(ua)) os = 'macOS';
+  else if (/android/i.test(ua)) os = 'Android';
+  else if (/linux/i.test(ua)) os = 'Linux';
+
+  let browser = 'Unknown Browser';
+  if (/edg\//i.test(ua)) browser = 'Edge';
+  else if (/opr\/|opera/i.test(ua)) browser = 'Opera';
+  else if (/chrome\//i.test(ua) && !/edg\//i.test(ua)) browser = 'Chrome';
+  else if (/crios\//i.test(ua)) browser = 'Chrome';
+  else if (/fxios\//i.test(ua)) browser = 'Firefox';
+  else if (/firefox\//i.test(ua)) browser = 'Firefox';
+  else if (/safari\//i.test(ua) && /version\//i.test(ua)) browser = 'Safari';
+
+  let deviceType = 'Desktop';
+  if (/ipad|tablet/i.test(ua)) deviceType = 'Tablet';
+  else if (/mobi|iphone|android/i.test(ua)) deviceType = 'Mobile';
+
+  const deviceLabel = `${browser} on ${os}`;
+
+  return { browser, os, deviceType, deviceLabel };
+}

--- a/test/CrmLoginApproval.test.mjs
+++ b/test/CrmLoginApproval.test.mjs
@@ -1,0 +1,392 @@
+import { describe, it, before, after, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import express from 'express';
+import jwt from 'jsonwebtoken';
+import mongoose from 'mongoose';
+
+import { getCrmJwtSecret, requireCrmUser, requireCrmAdmin } from '../Middlewares/CrmAuth.js';
+import { CrmUserModel } from '../Schema_Models/CrmUser.js';
+import { CrmSessionModel } from '../Schema_Models/CrmSessionModel.js';
+import { CrmLoginApprovalModel } from '../Schema_Models/CrmLoginApprovalModel.js';
+import { CrmTrustedDeviceModel } from '../Schema_Models/CrmTrustedDeviceModel.js';
+import { computeDeviceKey } from '../Utils/DeviceKey.js';
+import { requestCrmOtp, verifyCrmOtp, getLoginApprovalStatus } from '../Controllers/CrmAuthController.js';
+import { listPendingLoginApprovals, approveLoginApproval, denyLoginApproval } from '../Controllers/CrmLoginApprovalController.js';
+import { setOtp, getOtp } from '../Utils/CrmOtpCache.js';
+import crypto from 'crypto';
+
+const MONGO_URI = process.env.MONGO_URI;
+const TEST_BDA_EMAIL = '__test_bda@loginflow.local';
+const TEST_ADMIN_EMAIL = '__test_admin@loginflow.local';
+
+let app;
+let server;
+let baseUrl;
+
+function signAdminToken() {
+  return jwt.sign({ role: 'crm_admin', email: TEST_ADMIN_EMAIL }, getCrmJwtSecret(), { expiresIn: '1h' });
+}
+
+// Mirrors the real OTP hash the controller expects, so we can seed a "correct" OTP
+// without going through SendGrid.
+function otpHash(email, otp) {
+  const secret = process.env.CRM_OTP_HASH_SECRET || getCrmJwtSecret();
+  const value = `${email}|${String(otp).trim()}|${secret}`;
+  return crypto.createHash('sha256').update(value).digest('hex');
+}
+
+function seedOtp(email, otp) {
+  setOtp(email, {
+    otpHash: otpHash(email, otp),
+    expiresAtMs: Date.now() + 5 * 60 * 1000,
+    attemptsLeft: 5,
+  });
+}
+
+const CHROME_MAC_UA = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36';
+const FIREFOX_WIN_UA = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:125.0) Gecko/20100101 Firefox/125.0';
+
+async function cleanupAll() {
+  await CrmUserModel.deleteMany({ email: { $in: [TEST_BDA_EMAIL, TEST_ADMIN_EMAIL] } });
+  await CrmSessionModel.deleteMany({ email: { $in: [TEST_BDA_EMAIL, TEST_ADMIN_EMAIL] } });
+  await CrmLoginApprovalModel.deleteMany({ email: { $in: [TEST_BDA_EMAIL, TEST_ADMIN_EMAIL] } });
+  await CrmTrustedDeviceModel.deleteMany({ email: { $in: [TEST_BDA_EMAIL, TEST_ADMIN_EMAIL] } });
+}
+
+before(async () => {
+  await mongoose.connect(MONGO_URI);
+  await cleanupAll();
+
+  app = express();
+  app.set('trust proxy', true);
+  app.use(express.json());
+
+  app.post('/api/crm/auth/request-otp', requestCrmOtp);
+  app.post('/api/crm/auth/verify-otp', verifyCrmOtp);
+  app.get('/api/crm/auth/login-approval/:approvalId/status', getLoginApprovalStatus);
+  app.get('/protected', requireCrmUser, (req, res) => res.json({ success: true, crmUser: req.crmUser }));
+
+  app.get('/api/crm/admin/login-approvals', requireCrmAdmin, listPendingLoginApprovals);
+  app.post('/api/crm/admin/login-approvals/:approvalId/approve', requireCrmAdmin, approveLoginApproval);
+  app.post('/api/crm/admin/login-approvals/:approvalId/deny', requireCrmAdmin, denyLoginApproval);
+
+  await new Promise((resolve) => { server = app.listen(0, resolve); });
+  baseUrl = `http://127.0.0.1:${server.address().port}`;
+});
+
+after(async () => {
+  await cleanupAll();
+  await new Promise((resolve) => server.close(resolve));
+  await mongoose.disconnect();
+});
+
+beforeEach(async () => {
+  // Fresh BDA user + clean approval/trusted-device state before every test.
+  await CrmLoginApprovalModel.deleteMany({ email: TEST_BDA_EMAIL });
+  await CrmTrustedDeviceModel.deleteMany({ email: TEST_BDA_EMAIL });
+  await CrmSessionModel.deleteMany({ email: TEST_BDA_EMAIL });
+  await CrmUserModel.findOneAndUpdate(
+    { email: TEST_BDA_EMAIL },
+    { email: TEST_BDA_EMAIL, name: 'Test BDA', role: 'bda', isActive: true, permissions: [] },
+    { upsert: true }
+  );
+});
+
+describe('verifyCrmOtp — BDA new-device gate', () => {
+  it('a BDA logging in from a brand-new device gets pendingApproval, not a token', async () => {
+    seedOtp(TEST_BDA_EMAIL, '111111');
+    const res = await fetch(`${baseUrl}/api/crm/auth/verify-otp`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'User-Agent': CHROME_MAC_UA },
+      body: JSON.stringify({ email: TEST_BDA_EMAIL, otp: '111111' }),
+    });
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.pendingApproval, true);
+    assert.ok(body.approvalId);
+    assert.equal(body.token, undefined);
+  });
+
+  it('creates a pending CrmLoginApproval document with correct device/IP metadata', async () => {
+    seedOtp(TEST_BDA_EMAIL, '222222');
+    const res = await fetch(`${baseUrl}/api/crm/auth/verify-otp`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'User-Agent': CHROME_MAC_UA,
+        'X-Forwarded-For': '8.8.8.8',
+      },
+      body: JSON.stringify({ email: TEST_BDA_EMAIL, otp: '222222' }),
+    });
+    const body = await res.json();
+    const doc = await CrmLoginApprovalModel.findOne({ sessionId: body.approvalId });
+    assert.ok(doc);
+    assert.equal(doc.status, 'pending');
+    assert.equal(doc.email, TEST_BDA_EMAIL);
+    assert.equal(doc.browser, 'Chrome');
+    assert.equal(doc.os, 'macOS');
+    assert.equal(doc.ip, '8.8.8.8');
+    assert.equal(doc.country, 'United States');
+  });
+
+  it('GET login-approval status returns "pending" while awaiting admin action', async () => {
+    seedOtp(TEST_BDA_EMAIL, '333333');
+    const verifyRes = await fetch(`${baseUrl}/api/crm/auth/verify-otp`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'User-Agent': CHROME_MAC_UA },
+      body: JSON.stringify({ email: TEST_BDA_EMAIL, otp: '333333' }),
+    });
+    const { approvalId } = await verifyRes.json();
+
+    const statusRes = await fetch(`${baseUrl}/api/crm/auth/login-approval/${approvalId}/status`);
+    const statusBody = await statusRes.json();
+    assert.equal(statusBody.status, 'pending');
+  });
+
+  it('GET login-approval status for an unknown approvalId returns 404', async () => {
+    const res = await fetch(`${baseUrl}/api/crm/auth/login-approval/does-not-exist/status`);
+    assert.equal(res.status, 404);
+  });
+});
+
+describe('Admin approves a login', () => {
+  it('non-admin cannot list pending login approvals', async () => {
+    const userToken = jwt.sign({ role: 'crm_user', email: TEST_BDA_EMAIL }, getCrmJwtSecret(), { expiresIn: '1h' });
+    const res = await fetch(`${baseUrl}/api/crm/admin/login-approvals`, { headers: { Authorization: `Bearer ${userToken}` } });
+    assert.equal(res.status, 403);
+  });
+
+  it('admin sees the pending request in the list with device details', async () => {
+    seedOtp(TEST_BDA_EMAIL, '444444');
+    const verifyRes = await fetch(`${baseUrl}/api/crm/auth/verify-otp`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'User-Agent': CHROME_MAC_UA },
+      body: JSON.stringify({ email: TEST_BDA_EMAIL, otp: '444444' }),
+    });
+    const { approvalId } = await verifyRes.json();
+
+    const adminToken = signAdminToken();
+    const listRes = await fetch(`${baseUrl}/api/crm/admin/login-approvals`, { headers: { Authorization: `Bearer ${adminToken}` } });
+    const listBody = await listRes.json();
+    const found = listBody.data.find((a) => a.approvalId === approvalId);
+    assert.ok(found);
+    assert.equal(found.email, TEST_BDA_EMAIL);
+    assert.equal(found.deviceLabel, 'Chrome on macOS');
+  });
+
+  it('approving issues a token retrievable via the polling endpoint, and the BDA becomes fully logged in', async () => {
+    seedOtp(TEST_BDA_EMAIL, '555555');
+    const verifyRes = await fetch(`${baseUrl}/api/crm/auth/verify-otp`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'User-Agent': CHROME_MAC_UA },
+      body: JSON.stringify({ email: TEST_BDA_EMAIL, otp: '555555' }),
+    });
+    const { approvalId } = await verifyRes.json();
+
+    const adminToken = signAdminToken();
+    const approveRes = await fetch(`${baseUrl}/api/crm/admin/login-approvals/${approvalId}/approve`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${adminToken}` },
+    });
+    assert.equal(approveRes.status, 200);
+
+    // BDA's browser polls and should now receive a real, usable token.
+    const pollRes = await fetch(`${baseUrl}/api/crm/auth/login-approval/${approvalId}/status`);
+    const pollBody = await pollRes.json();
+    assert.equal(pollBody.status, 'approved');
+    assert.ok(pollBody.token);
+    assert.equal(pollBody.user.email, TEST_BDA_EMAIL);
+
+    // Prove the issued token actually authenticates against a protected route.
+    const protectedRes = await fetch(`${baseUrl}/protected`, { headers: { Authorization: `Bearer ${pollBody.token}` } });
+    assert.equal(protectedRes.status, 200);
+  });
+
+  it('the issued token is single-use over the polling endpoint (second poll does not leak it again)', async () => {
+    seedOtp(TEST_BDA_EMAIL, '666666');
+    const verifyRes = await fetch(`${baseUrl}/api/crm/auth/verify-otp`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'User-Agent': CHROME_MAC_UA },
+      body: JSON.stringify({ email: TEST_BDA_EMAIL, otp: '666666' }),
+    });
+    const { approvalId } = await verifyRes.json();
+    const adminToken = signAdminToken();
+    await fetch(`${baseUrl}/api/crm/admin/login-approvals/${approvalId}/approve`, { method: 'POST', headers: { Authorization: `Bearer ${adminToken}` } });
+
+    const firstPoll = await (await fetch(`${baseUrl}/api/crm/auth/login-approval/${approvalId}/status`)).json();
+    assert.ok(firstPoll.token);
+
+    const secondPoll = await (await fetch(`${baseUrl}/api/crm/auth/login-approval/${approvalId}/status`)).json();
+    assert.equal(secondPoll.status, 'approved');
+    assert.equal(secondPoll.token, undefined);
+  });
+
+  it('approving a login marks that device as trusted for future logins', async () => {
+    seedOtp(TEST_BDA_EMAIL, '777777');
+    const verifyRes = await fetch(`${baseUrl}/api/crm/auth/verify-otp`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'User-Agent': CHROME_MAC_UA, 'X-Forwarded-For': '1.2.3.4' },
+      body: JSON.stringify({ email: TEST_BDA_EMAIL, otp: '777777' }),
+    });
+    const { approvalId } = await verifyRes.json();
+    const adminToken = signAdminToken();
+    await fetch(`${baseUrl}/api/crm/admin/login-approvals/${approvalId}/approve`, { method: 'POST', headers: { Authorization: `Bearer ${adminToken}` } });
+
+    const expectedDeviceKey = computeDeviceKey(CHROME_MAC_UA, '1.2.3.4');
+    const trusted = await CrmTrustedDeviceModel.findOne({ email: TEST_BDA_EMAIL, deviceKey: expectedDeviceKey });
+    assert.ok(trusted, 'device should now be marked trusted');
+  });
+
+  it('a second login from the now-trusted device skips approval entirely and returns a token directly', async () => {
+    // First login + approval, to establish trust.
+    seedOtp(TEST_BDA_EMAIL, '888881');
+    const firstVerify = await fetch(`${baseUrl}/api/crm/auth/verify-otp`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'User-Agent': CHROME_MAC_UA, 'X-Forwarded-For': '5.6.7.8' },
+      body: JSON.stringify({ email: TEST_BDA_EMAIL, otp: '888881' }),
+    });
+    const { approvalId } = await firstVerify.json();
+    const adminToken = signAdminToken();
+    await fetch(`${baseUrl}/api/crm/admin/login-approvals/${approvalId}/approve`, { method: 'POST', headers: { Authorization: `Bearer ${adminToken}` } });
+
+    // Second login, same device+IP.
+    seedOtp(TEST_BDA_EMAIL, '888882');
+    const secondVerify = await fetch(`${baseUrl}/api/crm/auth/verify-otp`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'User-Agent': CHROME_MAC_UA, 'X-Forwarded-For': '5.6.7.8' },
+      body: JSON.stringify({ email: TEST_BDA_EMAIL, otp: '888882' }),
+    });
+    const secondBody = await secondVerify.json();
+    assert.equal(secondBody.pendingApproval, undefined);
+    assert.ok(secondBody.token, 'trusted device should get a token immediately, no approval needed');
+  });
+
+  it('a login from a different device (different browser) still requires fresh approval, even after another device was trusted', async () => {
+    seedOtp(TEST_BDA_EMAIL, '999991');
+    const firstVerify = await fetch(`${baseUrl}/api/crm/auth/verify-otp`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'User-Agent': CHROME_MAC_UA, 'X-Forwarded-For': '9.9.9.9' },
+      body: JSON.stringify({ email: TEST_BDA_EMAIL, otp: '999991' }),
+    });
+    const { approvalId } = await firstVerify.json();
+    const adminToken = signAdminToken();
+    await fetch(`${baseUrl}/api/crm/admin/login-approvals/${approvalId}/approve`, { method: 'POST', headers: { Authorization: `Bearer ${adminToken}` } });
+
+    // Different browser entirely (Firefox vs Chrome) from the same IP.
+    seedOtp(TEST_BDA_EMAIL, '999992');
+    const secondVerify = await fetch(`${baseUrl}/api/crm/auth/verify-otp`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'User-Agent': FIREFOX_WIN_UA, 'X-Forwarded-For': '9.9.9.9' },
+      body: JSON.stringify({ email: TEST_BDA_EMAIL, otp: '999992' }),
+    });
+    const secondBody = await secondVerify.json();
+    assert.equal(secondBody.pendingApproval, true, 'a genuinely different browser must re-trigger approval');
+  });
+});
+
+describe('Admin denies a login', () => {
+  it('denying sets status to denied and the polling BDA sees "denied"', async () => {
+    seedOtp(TEST_BDA_EMAIL, '121212');
+    const verifyRes = await fetch(`${baseUrl}/api/crm/auth/verify-otp`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'User-Agent': CHROME_MAC_UA },
+      body: JSON.stringify({ email: TEST_BDA_EMAIL, otp: '121212' }),
+    });
+    const { approvalId } = await verifyRes.json();
+    const adminToken = signAdminToken();
+
+    const denyRes = await fetch(`${baseUrl}/api/crm/admin/login-approvals/${approvalId}/deny`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${adminToken}` },
+    });
+    assert.equal(denyRes.status, 200);
+
+    const pollBody = await (await fetch(`${baseUrl}/api/crm/auth/login-approval/${approvalId}/status`)).json();
+    assert.equal(pollBody.status, 'denied');
+    assert.equal(pollBody.token, undefined);
+  });
+
+  it('a denied device is NOT marked trusted — a later login attempt is gated again', async () => {
+    seedOtp(TEST_BDA_EMAIL, '131313');
+    const verifyRes = await fetch(`${baseUrl}/api/crm/auth/verify-otp`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'User-Agent': CHROME_MAC_UA, 'X-Forwarded-For': '4.4.4.4' },
+      body: JSON.stringify({ email: TEST_BDA_EMAIL, otp: '131313' }),
+    });
+    const { approvalId } = await verifyRes.json();
+    const adminToken = signAdminToken();
+    await fetch(`${baseUrl}/api/crm/admin/login-approvals/${approvalId}/deny`, { method: 'POST', headers: { Authorization: `Bearer ${adminToken}` } });
+
+    const deviceKey = computeDeviceKey(CHROME_MAC_UA, '4.4.4.4');
+    const trusted = await CrmTrustedDeviceModel.findOne({ email: TEST_BDA_EMAIL, deviceKey });
+    assert.equal(trusted, null);
+
+    seedOtp(TEST_BDA_EMAIL, '141414');
+    const secondVerify = await fetch(`${baseUrl}/api/crm/auth/verify-otp`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'User-Agent': CHROME_MAC_UA, 'X-Forwarded-For': '4.4.4.4' },
+      body: JSON.stringify({ email: TEST_BDA_EMAIL, otp: '141414' }),
+    });
+    const secondBody = await secondVerify.json();
+    assert.equal(secondBody.pendingApproval, true, 'denied device must be re-gated on next attempt');
+  });
+});
+
+describe('Double-action safety', () => {
+  it('approving an already-approved request returns a conflict, not a duplicate token', async () => {
+    seedOtp(TEST_BDA_EMAIL, '151515');
+    const verifyRes = await fetch(`${baseUrl}/api/crm/auth/verify-otp`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'User-Agent': CHROME_MAC_UA },
+      body: JSON.stringify({ email: TEST_BDA_EMAIL, otp: '151515' }),
+    });
+    const { approvalId } = await verifyRes.json();
+    const adminToken = signAdminToken();
+
+    const first = await fetch(`${baseUrl}/api/crm/admin/login-approvals/${approvalId}/approve`, { method: 'POST', headers: { Authorization: `Bearer ${adminToken}` } });
+    assert.equal(first.status, 200);
+
+    const second = await fetch(`${baseUrl}/api/crm/admin/login-approvals/${approvalId}/approve`, { method: 'POST', headers: { Authorization: `Bearer ${adminToken}` } });
+    assert.equal(second.status, 409);
+  });
+
+  it('denying an already-approved request is rejected (cannot flip a decision)', async () => {
+    seedOtp(TEST_BDA_EMAIL, '161616');
+    const verifyRes = await fetch(`${baseUrl}/api/crm/auth/verify-otp`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'User-Agent': CHROME_MAC_UA },
+      body: JSON.stringify({ email: TEST_BDA_EMAIL, otp: '161616' }),
+    });
+    const { approvalId } = await verifyRes.json();
+    const adminToken = signAdminToken();
+    await fetch(`${baseUrl}/api/crm/admin/login-approvals/${approvalId}/approve`, { method: 'POST', headers: { Authorization: `Bearer ${adminToken}` } });
+
+    const denyAttempt = await fetch(`${baseUrl}/api/crm/admin/login-approvals/${approvalId}/deny`, { method: 'POST', headers: { Authorization: `Bearer ${adminToken}` } });
+    assert.equal(denyAttempt.status, 409);
+  });
+
+  it('approving a nonexistent approvalId returns 404', async () => {
+    const adminToken = signAdminToken();
+    const res = await fetch(`${baseUrl}/api/crm/admin/login-approvals/does-not-exist/approve`, { method: 'POST', headers: { Authorization: `Bearer ${adminToken}` } });
+    assert.equal(res.status, 404);
+  });
+});
+
+describe('Admin role bypasses the approval gate entirely', () => {
+  it('a user with role "admin" logging in from a new device gets a token directly, no approval needed', async () => {
+    await CrmUserModel.findOneAndUpdate(
+      { email: TEST_ADMIN_EMAIL },
+      { email: TEST_ADMIN_EMAIL, name: 'Test Admin User', role: 'admin', isActive: true, permissions: [] },
+      { upsert: true }
+    );
+    seedOtp(TEST_ADMIN_EMAIL, '171717');
+    const res = await fetch(`${baseUrl}/api/crm/auth/verify-otp`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'User-Agent': CHROME_MAC_UA },
+      body: JSON.stringify({ email: TEST_ADMIN_EMAIL, otp: '171717' }),
+    });
+    const body = await res.json();
+    assert.equal(body.pendingApproval, undefined);
+    assert.ok(body.token, 'admin-role users must never be gated by device approval');
+  });
+});

--- a/test/CrmSessions.test.mjs
+++ b/test/CrmSessions.test.mjs
@@ -1,0 +1,409 @@
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import express from 'express';
+import jwt from 'jsonwebtoken';
+import mongoose from 'mongoose';
+import crypto from 'crypto';
+
+import { getCrmJwtSecret, requireCrmUser } from '../Middlewares/CrmAuth.js';
+import { CrmSessionModel } from '../Schema_Models/CrmSessionModel.js';
+import { parseUserAgent } from '../Utils/UserAgentParser.js';
+import { getClientIp, detectCountryFromIp, initGeoIp } from '../Utils/GeoIP.js';
+import {
+  listMySessions,
+  revokeMySession,
+  listAllSessions,
+  adminRevokeSession,
+} from '../Controllers/CrmSessionController.js';
+import { requireCrmAdmin } from '../Middlewares/CrmAuth.js';
+
+const MONGO_URI = process.env.MONGO_URI;
+const TEST_EMAIL_A = '__test_a@sessions.local';
+const TEST_EMAIL_B = '__test_b@sessions.local';
+
+let app;
+let server;
+let baseUrl;
+
+function signUserToken(payload, opts = {}) {
+  return jwt.sign({ role: 'crm_user', ...payload }, getCrmJwtSecret(), { expiresIn: '1h', ...opts });
+}
+
+function signAdminToken(payload = {}) {
+  return jwt.sign({ role: 'crm_admin', ...payload }, getCrmJwtSecret(), { expiresIn: '1h' });
+}
+
+async function createSessionDoc(overrides = {}) {
+  const sessionId = crypto.randomUUID();
+  await CrmSessionModel.create({
+    sessionId,
+    email: TEST_EMAIL_A,
+    ip: '8.8.8.8',
+    countryCode: 'US',
+    country: 'United States',
+    browser: 'Chrome',
+    os: 'macOS',
+    deviceType: 'Desktop',
+    userAgent: 'test-agent',
+    lastSeenAt: new Date(),
+    expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+    ...overrides,
+    sessionId: overrides.sessionId || sessionId,
+  });
+  return overrides.sessionId || sessionId;
+}
+
+before(async () => {
+  await mongoose.connect(MONGO_URI);
+  await initGeoIp();
+
+  app = express();
+  app.set('trust proxy', true);
+  app.use(express.json());
+
+  // Minimal test harness protected route, mirroring how a real CRM route is wired.
+  app.get('/protected', requireCrmUser, (req, res) => {
+    res.json({ success: true, crmUser: req.crmUser });
+  });
+
+  app.get('/api/crm/sessions', requireCrmUser, listMySessions);
+  app.post('/api/crm/sessions/:sessionId/revoke', requireCrmUser, revokeMySession);
+  app.get('/api/crm/admin/sessions', requireCrmAdmin, listAllSessions);
+  app.post('/api/crm/admin/sessions/:sessionId/revoke', requireCrmAdmin, adminRevokeSession);
+
+  await new Promise((resolve) => {
+    server = app.listen(0, () => resolve());
+  });
+  const { port } = server.address();
+  baseUrl = `http://127.0.0.1:${port}`;
+});
+
+after(async () => {
+  // Clean up every test document this suite created, regardless of which test left it behind.
+  await CrmSessionModel.deleteMany({ email: { $in: [TEST_EMAIL_A, TEST_EMAIL_B] } });
+  await new Promise((resolve) => server.close(resolve));
+  await mongoose.disconnect();
+});
+
+describe('UserAgentParser', () => {
+  it('parses Chrome on macOS', () => {
+    const ua = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36';
+    const result = parseUserAgent(ua);
+    assert.equal(result.browser, 'Chrome');
+    assert.equal(result.os, 'macOS');
+    assert.equal(result.deviceType, 'Desktop');
+  });
+
+  it('parses Safari on iPhone as Mobile', () => {
+    const ua = 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4 Mobile/15E148 Safari/604.1';
+    const result = parseUserAgent(ua);
+    assert.equal(result.browser, 'Safari');
+    assert.equal(result.os, 'iOS');
+    assert.equal(result.deviceType, 'Mobile');
+  });
+
+  it('parses Edge on Windows (not misidentified as Chrome)', () => {
+    const ua = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36 Edg/124.0.0.0';
+    const result = parseUserAgent(ua);
+    assert.equal(result.browser, 'Edge');
+    assert.equal(result.os, 'Windows');
+  });
+
+  it('parses Android Firefox as Mobile', () => {
+    const ua = 'Mozilla/5.0 (Android 14; Mobile; rv:125.0) Gecko/125.0 Firefox/125.0';
+    const result = parseUserAgent(ua);
+    assert.equal(result.browser, 'Firefox');
+    assert.equal(result.os, 'Android');
+    assert.equal(result.deviceType, 'Mobile');
+  });
+
+  it('parses iPad as Tablet', () => {
+    const ua = 'Mozilla/5.0 (iPad; CPU OS 17_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4 Mobile/15E148 Safari/604.1';
+    const result = parseUserAgent(ua);
+    assert.equal(result.deviceType, 'Tablet');
+  });
+
+  it('handles empty/garbage UA without throwing', () => {
+    const result = parseUserAgent('');
+    assert.equal(result.browser, 'Unknown Browser');
+    assert.equal(result.os, 'Unknown OS');
+    const result2 = parseUserAgent(undefined);
+    assert.equal(result2.browser, 'Unknown Browser');
+  });
+});
+
+describe('getClientIp', () => {
+  it('prefers cf-connecting-ip over everything else', () => {
+    const ip = getClientIp({ headers: { 'cf-connecting-ip': '1.1.1.1', 'x-forwarded-for': '2.2.2.2' } });
+    assert.equal(ip, '1.1.1.1');
+  });
+
+  it('falls back to first IP in x-forwarded-for chain', () => {
+    const ip = getClientIp({ headers: { 'x-forwarded-for': '8.8.8.8, 10.0.0.1, 10.0.0.2' } });
+    assert.equal(ip, '8.8.8.8');
+  });
+
+  it('falls back to req.ip when no proxy headers present', () => {
+    const ip = getClientIp({ headers: {}, ip: '203.0.113.5' });
+    assert.equal(ip, '203.0.113.5');
+  });
+
+  it('strips IPv6-mapped IPv4 prefix', () => {
+    const ip = getClientIp({ headers: {}, ip: '::ffff:203.0.113.5' });
+    assert.equal(ip, '203.0.113.5');
+  });
+
+  it('returns null when nothing is available', () => {
+    const ip = getClientIp({ headers: {} });
+    assert.equal(ip, null);
+  });
+});
+
+describe('detectCountryFromIp', () => {
+  it('resolves a known US IP (Google DNS) to US', () => {
+    const { countryCode } = detectCountryFromIp('8.8.8.8');
+    assert.equal(countryCode, 'US');
+  });
+
+  it('does not throw on garbage IP input', () => {
+    assert.doesNotThrow(() => detectCountryFromIp('not-an-ip'));
+  });
+
+  it('returns a default (not a crash) for null IP', () => {
+    const result = detectCountryFromIp(null);
+    assert.ok(result.countryCode);
+  });
+});
+
+describe('requireCrmUser middleware — session enforcement', () => {
+  it('rejects request with no Authorization header', async () => {
+    const res = await fetch(`${baseUrl}/protected`);
+    assert.equal(res.status, 401);
+  });
+
+  it('rejects malformed bearer token', async () => {
+    const res = await fetch(`${baseUrl}/protected`, { headers: { Authorization: 'Bearer not-a-real-jwt' } });
+    assert.equal(res.status, 401);
+  });
+
+  it('rejects token signed with wrong secret', async () => {
+    const badToken = jwt.sign({ role: 'crm_user', email: TEST_EMAIL_A }, 'wrong-secret', { expiresIn: '1h' });
+    const res = await fetch(`${baseUrl}/protected`, { headers: { Authorization: `Bearer ${badToken}` } });
+    assert.equal(res.status, 401);
+  });
+
+  it('rejects token with wrong role', async () => {
+    const token = jwt.sign({ role: 'crm_admin', email: TEST_EMAIL_A }, getCrmJwtSecret(), { expiresIn: '1h' });
+    const res = await fetch(`${baseUrl}/protected`, { headers: { Authorization: `Bearer ${token}` } });
+    assert.equal(res.status, 403);
+  });
+
+  it('allows a legacy token with no sessionId claim (backward compatibility)', async () => {
+    const token = signUserToken({ email: TEST_EMAIL_A, permissions: [] }); // no sessionId
+    const res = await fetch(`${baseUrl}/protected`, { headers: { Authorization: `Bearer ${token}` } });
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.crmUser.email, TEST_EMAIL_A);
+  });
+
+  it('allows a valid session-bound token and bumps lastSeenAt', async () => {
+    const sessionId = await createSessionDoc({ lastSeenAt: new Date(Date.now() - 60_000) });
+    const before = await CrmSessionModel.findOne({ sessionId });
+    const token = signUserToken({ email: TEST_EMAIL_A, permissions: [], sessionId });
+
+    const res = await fetch(`${baseUrl}/protected`, { headers: { Authorization: `Bearer ${token}` } });
+    assert.equal(res.status, 200);
+
+    const after = await CrmSessionModel.findOne({ sessionId });
+    assert.ok(after.lastSeenAt.getTime() > before.lastSeenAt.getTime(), 'lastSeenAt should be bumped forward');
+  });
+
+  it('rejects a token whose session has been revoked — the core kill-switch behavior', async () => {
+    const sessionId = await createSessionDoc({ revoked: true, revokedAt: new Date() });
+    const token = signUserToken({ email: TEST_EMAIL_A, permissions: [], sessionId });
+
+    const res = await fetch(`${baseUrl}/protected`, { headers: { Authorization: `Bearer ${token}` } });
+    assert.equal(res.status, 401);
+    const body = await res.json();
+    assert.match(body.error, /revoked/i);
+  });
+
+  it('rejects a token referencing a sessionId that does not exist in DB (edge case — should not crash)', async () => {
+    const token = signUserToken({ email: TEST_EMAIL_A, permissions: [], sessionId: 'nonexistent-session-id' });
+    const res = await fetch(`${baseUrl}/protected`, { headers: { Authorization: `Bearer ${token}` } });
+    // No matching session row means nothing to enforce against — middleware should let it through
+    // (this documents actual current behavior so a future change is a deliberate decision, not a surprise)
+    assert.equal(res.status, 200);
+  });
+});
+
+describe('GET /api/crm/sessions — list my sessions', () => {
+  it('returns only sessions for the requesting users own email, not other users', async () => {
+    const mySessionId = await createSessionDoc({ email: TEST_EMAIL_A });
+    const otherSessionId = await createSessionDoc({ email: TEST_EMAIL_B });
+
+    const token = signUserToken({ email: TEST_EMAIL_A, permissions: [], sessionId: mySessionId });
+    const res = await fetch(`${baseUrl}/api/crm/sessions`, { headers: { Authorization: `Bearer ${token}` } });
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.ok(body.success);
+    const ids = body.data.map((s) => s.sessionId);
+    assert.ok(ids.includes(mySessionId));
+    assert.ok(!ids.includes(otherSessionId));
+  });
+
+  it('marks the callers own current session as isCurrent: true', async () => {
+    const sessionId = await createSessionDoc({ email: TEST_EMAIL_A });
+    const token = signUserToken({ email: TEST_EMAIL_A, permissions: [], sessionId });
+
+    const res = await fetch(`${baseUrl}/api/crm/sessions`, { headers: { Authorization: `Bearer ${token}` } });
+    const body = await res.json();
+    const mine = body.data.find((s) => s.sessionId === sessionId);
+    assert.equal(mine.isCurrent, true);
+  });
+
+  it('excludes revoked sessions from the list', async () => {
+    const sessionId = await createSessionDoc({ email: TEST_EMAIL_A, revoked: true });
+    const activeSessionId = await createSessionDoc({ email: TEST_EMAIL_A });
+    const token = signUserToken({ email: TEST_EMAIL_A, permissions: [], sessionId: activeSessionId });
+
+    const res = await fetch(`${baseUrl}/api/crm/sessions`, { headers: { Authorization: `Bearer ${token}` } });
+    const body = await res.json();
+    const ids = body.data.map((s) => s.sessionId);
+    assert.ok(!ids.includes(sessionId));
+    assert.ok(ids.includes(activeSessionId));
+  });
+
+  it('includes device/IP/location fields in the response shape', async () => {
+    const sessionId = await createSessionDoc({ email: TEST_EMAIL_A, ip: '8.8.8.8', country: 'United States' });
+    const token = signUserToken({ email: TEST_EMAIL_A, permissions: [], sessionId });
+
+    const res = await fetch(`${baseUrl}/api/crm/sessions`, { headers: { Authorization: `Bearer ${token}` } });
+    const body = await res.json();
+    const mine = body.data.find((s) => s.sessionId === sessionId);
+    assert.equal(mine.ip, '8.8.8.8');
+    assert.equal(mine.country, 'United States');
+    assert.equal(mine.deviceLabel, 'Chrome on macOS');
+  });
+});
+
+describe('POST /api/crm/sessions/:sessionId/revoke — self revoke', () => {
+  it('revokes own session successfully', async () => {
+    const sessionId = await createSessionDoc({ email: TEST_EMAIL_A });
+    const token = signUserToken({ email: TEST_EMAIL_A, permissions: [] }); // acting from a different session
+
+    const res = await fetch(`${baseUrl}/api/crm/sessions/${sessionId}/revoke`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    assert.equal(res.status, 200);
+
+    const doc = await CrmSessionModel.findOne({ sessionId });
+    assert.equal(doc.revoked, true);
+    assert.ok(doc.revokedAt);
+  });
+
+  it('a revoked session immediately blocks that devices subsequent requests (end-to-end kill-switch)', async () => {
+    const sessionId = await createSessionDoc({ email: TEST_EMAIL_A });
+    const deviceToken = signUserToken({ email: TEST_EMAIL_A, permissions: [], sessionId });
+
+    // Device works fine before revoke.
+    const before = await fetch(`${baseUrl}/protected`, { headers: { Authorization: `Bearer ${deviceToken}` } });
+    assert.equal(before.status, 200);
+
+    // Revoke it from "another device" (any valid token for the same user).
+    const revokerToken = signUserToken({ email: TEST_EMAIL_A, permissions: [] });
+    const revokeRes = await fetch(`${baseUrl}/api/crm/sessions/${sessionId}/revoke`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${revokerToken}` },
+    });
+    assert.equal(revokeRes.status, 200);
+
+    // The original device's still-unexpired JWT must now be rejected.
+    const after = await fetch(`${baseUrl}/protected`, { headers: { Authorization: `Bearer ${deviceToken}` } });
+    assert.equal(after.status, 401);
+  });
+
+  it('rejects revoking a session that belongs to a different user', async () => {
+    const otherSessionId = await createSessionDoc({ email: TEST_EMAIL_B });
+    const token = signUserToken({ email: TEST_EMAIL_A, permissions: [] });
+
+    const res = await fetch(`${baseUrl}/api/crm/sessions/${otherSessionId}/revoke`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    assert.equal(res.status, 403);
+
+    const doc = await CrmSessionModel.findOne({ sessionId: otherSessionId });
+    assert.equal(doc.revoked, false, 'other users session must remain untouched');
+  });
+
+  it('returns 404 for a sessionId that does not exist', async () => {
+    const token = signUserToken({ email: TEST_EMAIL_A, permissions: [] });
+    const res = await fetch(`${baseUrl}/api/crm/sessions/does-not-exist/revoke`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    assert.equal(res.status, 404);
+  });
+
+  it('revoking an already-revoked session is idempotent (no error)', async () => {
+    const sessionId = await createSessionDoc({ email: TEST_EMAIL_A, revoked: true });
+    const token = signUserToken({ email: TEST_EMAIL_A, permissions: [] });
+
+    const res = await fetch(`${baseUrl}/api/crm/sessions/${sessionId}/revoke`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    assert.equal(res.status, 200);
+  });
+});
+
+describe('Admin session endpoints', () => {
+  it('GET /api/crm/admin/sessions rejects a non-admin (crm_user) token', async () => {
+    const token = signUserToken({ email: TEST_EMAIL_A, permissions: [] });
+    const res = await fetch(`${baseUrl}/api/crm/admin/sessions`, { headers: { Authorization: `Bearer ${token}` } });
+    assert.equal(res.status, 403);
+  });
+
+  it('GET /api/crm/admin/sessions returns sessions across multiple users', async () => {
+    const sessionA = await createSessionDoc({ email: TEST_EMAIL_A });
+    const sessionB = await createSessionDoc({ email: TEST_EMAIL_B });
+    const adminToken = signAdminToken();
+
+    const res = await fetch(`${baseUrl}/api/crm/admin/sessions`, { headers: { Authorization: `Bearer ${adminToken}` } });
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    const ids = body.data.map((s) => s.sessionId);
+    assert.ok(ids.includes(sessionA));
+    assert.ok(ids.includes(sessionB));
+  });
+
+  it('admin can revoke any users session', async () => {
+    const sessionId = await createSessionDoc({ email: TEST_EMAIL_B });
+    const adminToken = signAdminToken();
+
+    const res = await fetch(`${baseUrl}/api/crm/admin/sessions/${sessionId}/revoke`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${adminToken}` },
+    });
+    assert.equal(res.status, 200);
+
+    const doc = await CrmSessionModel.findOne({ sessionId });
+    assert.equal(doc.revoked, true);
+  });
+
+  it('a non-admin crm_user cannot hit the admin revoke endpoint', async () => {
+    const sessionId = await createSessionDoc({ email: TEST_EMAIL_B });
+    const userToken = signUserToken({ email: TEST_EMAIL_A, permissions: [] });
+
+    const res = await fetch(`${baseUrl}/api/crm/admin/sessions/${sessionId}/revoke`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${userToken}` },
+    });
+    assert.equal(res.status, 403);
+
+    const doc = await CrmSessionModel.findOne({ sessionId });
+    assert.equal(doc.revoked, false);
+  });
+});


### PR DESCRIPTION
- New crm_sessions collection tracks device/IP/location per CRM login; requireCrmUser now checks for revocation on every request
- New endpoints to list/revoke sessions (self and admin-wide)
- BDAs logging in from an unrecognized device are held pending until an admin approves; approved devices are remembered so future logins skip the gate. Admins bypass this entirely.
- 52 tests covering session lifecycle, revocation kill-switch, and the full login-approval flow (new device, trusted device, deny, double-action safety, admin bypass)