### PR TITLE
Route all BDA meeting alerts to a single shared Discord channel

### DIFF
--- a/Utils/DiscordMeetReminderScheduler.js
+++ b/Utils/DiscordMeetReminderScheduler.js
@@ -27,20 +27,13 @@ const STUCK_PROCESSING_MS = Math.max(
   Number(process.env.DISCORD_MEET_REMINDER_STUCK_PROCESSING_MS) || 8 * 60 * 1000
 );
 
+// Every BDA's meeting reminder goes to this single shared channel; the
+// "Assigned BDA" line in the message body identifies who it's for.
 const DISCORD_MEET_2MIN_WEBHOOK_URL =
   process.env.DISCORD_MEET_2MIN_WEBHOOK_URL ||
   process.env.DISCORD_MEET_WEB_HOOK_URL ||
   process.env.DISCORD_REMINDER_CALL_WEBHOOK_URL ||
   null;
-
-// Meetings assigned to a BDA whose name starts with "Kalpataru" get their
-// confirm-attendance reminder routed to a dedicated Discord channel instead of
-// the shared one. Falls back to the shared webhook if not configured.
-// Env can override; hardcoded default keeps the dedicated channel working even
-// when the env var is missing on a deploy.
-const DISCORD_MEET_KALPATARU_WEBHOOK_URL =
-  process.env.DISCORD_MEET_KALPATARU_WEBHOOK_URL ||
-  'https://discord.com/api/webhooks/1523575499454939307/i_ESYLBr2ADfKJlB_Owb0aFub1LRivpN1us8Xrbf0vIFKB-TsK8RQefcG3PTDRjojgat';
 
 let isRunning = false;
 let pollInterval = null;
@@ -445,16 +438,7 @@ export async function processDueDiscordMeetReminders() {
 
         logReminderDrift('discord_bda', reminder.reminderId, reminder.scheduledFor);
 
-        // Route to the Kalpataru channel when the assigned BDA's name starts with
-        // "Kalpataru"; otherwise use the shared channel. Match on name only.
-        const assignedBdaName = (booking?.calendlyHost?.name || booking?.claimedBy?.name || '').trim();
-        const isKalpataru = /^kalpataru/i.test(assignedBdaName);
-        const targetWebhookUrl =
-          isKalpataru && DISCORD_MEET_KALPATARU_WEBHOOK_URL
-            ? DISCORD_MEET_KALPATARU_WEBHOOK_URL
-            : DISCORD_MEET_2MIN_WEBHOOK_URL;
-
-        const sendResult = await DiscordConnect(targetWebhookUrl, content, false);
+        const sendResult = await DiscordConnect(DISCORD_MEET_2MIN_WEBHOOK_URL, content, false);
         if (!sendResult.ok) {
           throw new Error(`Discord send failed: ${sendResult.error || 'unknown'}`);
         }

--- a/Utils/UnifiedScheduler.js
+++ b/Utils/UnifiedScheduler.js
@@ -42,13 +42,6 @@ const DISCORD_MEET_WEBHOOK =
   process.env.DISCORD_REMINDER_CALL_WEBHOOK_URL ||
   null;
 
-// Meetings assigned to a BDA whose name starts with "Kalpataru" route to a
-// dedicated Discord channel. Env can override; the hardcoded URL is the default
-// so the channel keeps working even when the env var is missing on a deploy.
-const DISCORD_MEET_KALPATARU_WEBHOOK =
-  process.env.DISCORD_MEET_KALPATARU_WEBHOOK_URL ||
-  'https://discord.com/api/webhooks/1523575499454939307/i_ESYLBr2ADfKJlB_Owb0aFub1LRivpN1us8Xrbf0vIFKB-TsK8RQefcG3PTDRjojgat';
-
 export class UnifiedScheduler {
   constructor() {
     this.timers = new Map();
@@ -578,13 +571,8 @@ export class UnifiedScheduler {
       const meetingTimeWall = formatMeetingWallTime(meetingStart, reminder.inviteeTimezone);
       const headline = headlineForSendTime(meetingStart);
 
-      // Resolve the assigned BDA up front — it both drives channel routing below
-      // and is shown in the message so the team can verify at a glance which BDA
-      // (and therefore which channel) a reminder belongs to.
-      // Route to the Kalpataru channel when the assigned BDA's name starts with
-      // "Kalpataru" (Calendly round-robin host, else manual CRM claim); otherwise
-      // use the shared channel. Mirrors the legacy DiscordMeetReminderScheduler
-      // routing — this precision path is the one that actually wins the claim.
+      // Resolve the assigned BDA so the message can show who this meeting belongs
+      // to — every reminder goes to the one shared channel (DISCORD_MEET_WEBHOOK).
       const bookingForRoute =
         (bIdDisc && bookingMap.byId.get(bIdDisc)) ||
         ((reminder.clientEmail || '') && bookingMap.byEmail.get(String(reminder.clientEmail).toLowerCase().trim())) ||
@@ -599,11 +587,7 @@ export class UnifiedScheduler {
         bookingForRoute?.calendlyHost?.email ||
         bookingForRoute?.claimedBy?.email ||
         'Not assigned';
-      const isKalpataru = /^kalpataru/i.test(assignedBdaName);
-      const targetWebhook =
-        isKalpataru && DISCORD_MEET_KALPATARU_WEBHOOK
-          ? DISCORD_MEET_KALPATARU_WEBHOOK
-          : DISCORD_MEET_WEBHOOK;
+      const targetWebhook = DISCORD_MEET_WEBHOOK;
 
       const content = [
         headline,


### PR DESCRIPTION
There were two separate schedulers (DiscordMeetReminderScheduler and UnifiedScheduler) each independently routing meetings assigned to a BDA named "Kalpataru" to a second, dedicated Discord channel — a fork that was undocumented outside a code comment and made it unclear where an alert would land. Removed the per-BDA channel routing from both; every meeting reminder now goes to the one shared channel, with the "Assigned BDA" line in the message identifying who it's for.