### PR TITLE
Scope the Leads tab to each BDA's own assigned leads

### DIFF
--- a/Controllers/CampaignBookingController.js
+++ b/Controllers/CampaignBookingController.js
@@ -18,7 +18,29 @@ import { sendScheduleEvent } from '../Services/FacebookConversionAPI.js';
 import { sendScheduleEvent as sendGoogleAdsScheduleEvent } from '../Services/GoogleAdsConversionAPI.js';
 import { sendScheduleEvent as sendLinkedInScheduleEvent } from '../Services/LinkedInConversionAPI.js';
 import { normalizePhoneForMatching } from '../Utils/normalizePhoneForMatching.js';
-import { crmUserMetaLeadsOnly } from '../Middlewares/CrmAuth.js';
+import { crmUserMetaLeadsOnly, crmUserBdaOwnEmailScope } from '../Middlewares/CrmAuth.js';
+
+/**
+ * Restricts a leads query to the requesting BDA's own assigned leads, while still
+ * showing leads with no resolved calendlyHost (so nothing becomes invisible to
+ * everyone just because it predates round-robin Calendly scheduling, or came in
+ * as a Meta lead that never got a host resolved).
+ * No-op (returns matchQuery unchanged) for admins.
+ */
+function applyBdaOwnLeadScope(matchQuery, req) {
+  const ownEmail = crmUserBdaOwnEmailScope(req);
+  if (!ownEmail) return matchQuery;
+
+  matchQuery.$and = matchQuery.$and || [];
+  matchQuery.$and.push({
+    $or: [
+      { 'calendlyHost.email': caseInsensitiveExact(ownEmail) },
+      { 'calendlyHost.email': { $in: [null, ''] } },
+      { calendlyHost: { $exists: false } },
+    ],
+  });
+  return matchQuery;
+}
 
 import { logReminderError } from '../Schema_Models/ReminderError.js';
 import { validatePostMeetingBookingStatus } from '../Utils/meetingStatusEligibility.js';
@@ -2076,10 +2098,12 @@ export const getLeadsPaginated = async (req, res) => {
       });
     }
 
+    applyBdaOwnLeadScope(matchQuery, req);
+
     // For Meta leads (meta_lead_ad), show ALL leads including duplicates
     // For other leads, group by email/phone to show unique leads only
     const isMetaLeadsOnly = utmSource === 'meta_lead_ad';
-    
+
     const pipeline = [
       { $match: matchQuery },
       {
@@ -2415,6 +2439,8 @@ export const getLeadsIds = async (req, res) => {
         ]
       });
     }
+
+    applyBdaOwnLeadScope(matchQuery, req);
 
     const idsPipeline = [
       { $match: matchQuery },
@@ -2914,6 +2940,8 @@ export const getLeadsAnalytics = async (req, res) => {
         ]
       });
     }
+
+    applyBdaOwnLeadScope(matchQuery, req);
 
     // Qualification add-fields expression (reusable)
     const qualExpr = {

--- a/Controllers/CrmAuthController.js
+++ b/Controllers/CrmAuthController.js
@@ -25,6 +25,10 @@ export async function issueCrmSessionAndToken({ user, ip, countryCode, country, 
   const token = jwt.sign(
     {
       role: 'crm_user',
+      // Distinct from the `role` claim above (which is the auth-role used by
+      // requireCrmUser/requireCrmAdmin) — this carries the CrmUser.role value
+      // (admin/bda) so per-request BDA scoping can read it without a DB lookup.
+      bdaRole: user.role || 'bda',
       email: user.email,
       name: user.name,
       permissions: user.permissions || [],

--- a/Middlewares/CrmAuth.js
+++ b/Middlewares/CrmAuth.js
@@ -110,6 +110,24 @@ export function crmUserMetaLeadsOnly(req) {
   return perms.includes('meta_leads') && !perms.includes('leads');
 }
 
+/**
+ * Returns the requesting BDA's own email if the Leads list should be scoped to
+ * only their assigned leads, or null if the request should see everyone's leads
+ * (admins, and anyone whose role isn't 'bda').
+ *
+ * Leads with no resolved calendlyHost (old bookings, or Meta-lead bookings that
+ * never got a host resolved) are intentionally left visible to every BDA — the
+ * scope only ever narrows leads that DO have a clear owner.
+ */
+export function crmUserBdaOwnEmailScope(req) {
+  // bdaRole carries CrmUser.role (admin/bda); absent on tokens issued before this
+  // field existed, or on non-crm_user tokens — treat anything but an explicit
+  // 'bda' as unscoped so nobody is unexpectedly locked out by an old token.
+  if (req.crmUser?.bdaRole !== 'bda') return null;
+  const email = req.crmUser?.email;
+  return email ? String(email).toLowerCase().trim() : null;
+}
+
 export function requireCrmAnyPermission(permissions) {
   const list = Array.isArray(permissions) ? permissions : [];
   return (req, res, next) => {

--- a/test/BdaLeadScoping.test.mjs
+++ b/test/BdaLeadScoping.test.mjs
@@ -1,0 +1,152 @@
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import express from 'express';
+import jwt from 'jsonwebtoken';
+import mongoose from 'mongoose';
+
+import { getCrmJwtSecret, requireCrmUser, requireCrmAnyPermission } from '../Middlewares/CrmAuth.js';
+import { CampaignBookingModel } from '../Schema_Models/CampaignBooking.js';
+import { getLeadsPaginated, getLeadsIds, getLeadsAnalytics } from '../Controllers/CampaignBookingController.js';
+
+const MONGO_URI = process.env.MONGO_URI;
+const BOOKING_ID_PREFIX = '__test_bdascope_';
+
+let app;
+let server;
+let baseUrl;
+
+function signToken({ email, bdaRole }) {
+  return jwt.sign({ role: 'crm_user', permissions: ['leads'], email, bdaRole }, getCrmJwtSecret(), { expiresIn: '1h' });
+}
+
+async function seedBooking(overrides = {}) {
+  const bookingId = `${BOOKING_ID_PREFIX}${Math.random().toString(36).slice(2)}`;
+  await CampaignBookingModel.create({
+    bookingId,
+    clientName: 'Test Client',
+    clientEmail: `${bookingId}@example.com`,
+    bookingStatus: 'scheduled',
+    utmSource: 'direct',
+    scheduledEventStartTime: new Date(Date.now() + 24 * 60 * 60 * 1000),
+    bookingCreatedAt: new Date(),
+    ...overrides,
+  });
+  return bookingId;
+}
+
+async function cleanupAll() {
+  await CampaignBookingModel.deleteMany({ bookingId: { $regex: `^${BOOKING_ID_PREFIX}` } });
+}
+
+before(async () => {
+  await mongoose.connect(MONGO_URI);
+  await cleanupAll();
+
+  app = express();
+  app.use(express.json());
+  app.get('/api/leads/paginated', requireCrmUser, requireCrmAnyPermission(['leads', 'meta_leads']), getLeadsPaginated);
+  app.get('/api/leads/ids', requireCrmUser, requireCrmAnyPermission(['leads', 'meta_leads']), getLeadsIds);
+  app.get('/api/leads/analytics', requireCrmUser, requireCrmAnyPermission(['leads', 'meta_leads', 'lead_analytics']), getLeadsAnalytics);
+
+  await new Promise((resolve) => { server = app.listen(0, resolve); });
+  baseUrl = `http://127.0.0.1:${server.address().port}`;
+});
+
+after(async () => {
+  await cleanupAll();
+  await new Promise((resolve) => server.close(resolve));
+  await mongoose.disconnect();
+});
+
+describe('BDA lead visibility scoping', () => {
+  it('a BDA only sees leads assigned to their own calendlyHost.email in the paginated list', async () => {
+    const siddharthaBooking = await seedBooking({ calendlyHost: { email: 'siddhartha@flashfirehq.com', name: 'Siddhartha', matchedCrmUser: true } });
+    const kalpataruBooking = await seedBooking({ calendlyHost: { email: 'kalpataru@flashfirehq.com', name: 'Kalpataru', matchedCrmUser: true } });
+
+    const token = signToken({ email: 'siddhartha@flashfirehq.com', bdaRole: 'bda' });
+    const res = await fetch(`${baseUrl}/api/leads/paginated?limit=200`, { headers: { Authorization: `Bearer ${token}` } });
+    const body = await res.json();
+    const ids = body.data.map((l) => l.bookingId);
+
+    assert.ok(ids.includes(siddharthaBooking), 'Siddhartha should see his own lead');
+    assert.ok(!ids.includes(kalpataruBooking), 'Siddhartha should NOT see Kalpataru\'s lead');
+  });
+
+  it('an admin sees leads from every BDA in the paginated list', async () => {
+    const siddharthaBooking = await seedBooking({ calendlyHost: { email: 'siddhartha@flashfirehq.com', name: 'Siddhartha', matchedCrmUser: true } });
+    const kalpataruBooking = await seedBooking({ calendlyHost: { email: 'kalpataru@flashfirehq.com', name: 'Kalpataru', matchedCrmUser: true } });
+
+    const adminToken = signToken({ email: 'admin@flashfirehq.com', bdaRole: 'admin' });
+    const res = await fetch(`${baseUrl}/api/leads/paginated?limit=200`, { headers: { Authorization: `Bearer ${adminToken}` } });
+    const body = await res.json();
+    const ids = body.data.map((l) => l.bookingId);
+
+    assert.ok(ids.includes(siddharthaBooking), 'Admin should see Siddhartha\'s lead');
+    assert.ok(ids.includes(kalpataruBooking), 'Admin should see Kalpataru\'s lead');
+  });
+
+  it('leads with no calendlyHost at all remain visible to every BDA', async () => {
+    const unassignedBooking = await seedBooking({});
+
+    const siddharthaToken = signToken({ email: 'siddhartha@flashfirehq.com', bdaRole: 'bda' });
+    const kalpataruToken = signToken({ email: 'kalpataru@flashfirehq.com', bdaRole: 'bda' });
+
+    const resA = await fetch(`${baseUrl}/api/leads/paginated?limit=200`, { headers: { Authorization: `Bearer ${siddharthaToken}` } });
+    const bodyA = await resA.json();
+    assert.ok(bodyA.data.map((l) => l.bookingId).includes(unassignedBooking), 'Unassigned lead visible to Siddhartha');
+
+    const resB = await fetch(`${baseUrl}/api/leads/paginated?limit=200`, { headers: { Authorization: `Bearer ${kalpataruToken}` } });
+    const bodyB = await resB.json();
+    assert.ok(bodyB.data.map((l) => l.bookingId).includes(unassignedBooking), 'Unassigned lead also visible to Kalpataru');
+  });
+
+  it('leads with calendlyHost.matchedCrmUser: false and no email (the Mongoose-default broken shape) still count as unassigned, visible to all', async () => {
+    const brokenShapeBooking = await seedBooking({ calendlyHost: { matchedCrmUser: false } });
+
+    const token = signToken({ email: 'siddhartha@flashfirehq.com', bdaRole: 'bda' });
+    const res = await fetch(`${baseUrl}/api/leads/paginated?limit=200`, { headers: { Authorization: `Bearer ${token}` } });
+    const body = await res.json();
+    assert.ok(body.data.map((l) => l.bookingId).includes(brokenShapeBooking), 'Broken-shape calendlyHost (no email) should be treated as unassigned, not silently hidden');
+  });
+
+  it('getLeadsIds applies the same BDA scope as the paginated list', async () => {
+    const siddharthaBooking = await seedBooking({ calendlyHost: { email: 'siddhartha@flashfirehq.com', name: 'Siddhartha', matchedCrmUser: true } });
+    const kalpataruBooking = await seedBooking({ calendlyHost: { email: 'kalpataru@flashfirehq.com', name: 'Kalpataru', matchedCrmUser: true } });
+
+    const token = signToken({ email: 'kalpataru@flashfirehq.com', bdaRole: 'bda' });
+    const res = await fetch(`${baseUrl}/api/leads/ids?limit=5000`, { headers: { Authorization: `Bearer ${token}` } });
+    const body = await res.json();
+
+    assert.ok(body.data.bookingIds.includes(kalpataruBooking), 'Kalpataru should see his own lead id');
+    assert.ok(!body.data.bookingIds.includes(siddharthaBooking), 'Kalpataru should not see Siddhartha\'s lead id');
+  });
+
+  it('getLeadsAnalytics counts only reflect the requesting BDA\'s own leads (relative to baseline, since unassigned production leads are legitimately included for everyone)', async () => {
+    const token = signToken({ email: 'siddhartha@flashfirehq.com', bdaRole: 'bda' });
+
+    const before = await (await fetch(`${baseUrl}/api/leads/analytics`, { headers: { Authorization: `Bearer ${token}` } })).json();
+    const baselineTotal = before.data.funnel.total;
+
+    await seedBooking({ calendlyHost: { email: 'siddhartha@flashfirehq.com', name: 'Siddhartha', matchedCrmUser: true }, bookingStatus: 'not-scheduled' });
+    await seedBooking({ calendlyHost: { email: 'siddhartha@flashfirehq.com', name: 'Siddhartha', matchedCrmUser: true }, bookingStatus: 'not-scheduled' });
+    await seedBooking({ calendlyHost: { email: 'kalpataru@flashfirehq.com', name: 'Kalpataru', matchedCrmUser: true }, bookingStatus: 'not-scheduled' });
+
+    const after = await (await fetch(`${baseUrl}/api/leads/analytics`, { headers: { Authorization: `Bearer ${token}` } })).json();
+    const afterTotal = after.data.funnel.total;
+
+    assert.equal(afterTotal - baselineTotal, 2, 'adding 2 of Siddhartha\'s leads + 1 of Kalpataru\'s should only raise Siddhartha\'s own count by 2');
+  });
+
+  it('a BDA cannot bypass scoping by passing a different bdaEmail query param', async () => {
+    const token = signToken({ email: 'siddhartha@flashfirehq.com', bdaRole: 'bda' });
+    const before = await (await fetch(`${baseUrl}/api/leads/analytics?bdaEmail=kalpataru@flashfirehq.com`, { headers: { Authorization: `Bearer ${token}` } })).json();
+    const baselineTotal = before.data.funnel.total;
+
+    await seedBooking({ calendlyHost: { email: 'kalpataru@flashfirehq.com', name: 'Kalpataru', matchedCrmUser: true }, bookingStatus: 'not-scheduled' });
+
+    const after = await (await fetch(`${baseUrl}/api/leads/analytics?bdaEmail=kalpataru@flashfirehq.com`, { headers: { Authorization: `Bearer ${token}` } })).json();
+    const afterTotal = after.data.funnel.total;
+
+    assert.equal(afterTotal, baselineTotal, 'Siddhartha must not see Kalpataru\'s newly added lead even via a bdaEmail query param override attempt');
+  });
+});


### PR DESCRIPTION
A BDA now only sees leads whose calendlyHost.email matches their own — Siddhartha no longer sees Kalpataru's leads and vice versa, across the leads table, bulk-select (ids), and analytics endpoints. Leads with no resolved calendlyHost (old bookings, or Meta-lead bookings that never got a host resolved) remain visible to every BDA so nothing becomes invisible; admins are unaffected and continue to see everything.

Also added a `bdaRole` claim (admin/bda) to the CRM JWT — the existing `role` claim only ever carries the auth-role ('crm_user'/'crm_admin'), so there was previously no way for endpoint-level scoping to know a token belongs to a BDA specifically. Tokens issued before this change lack bdaRole and are treated as unscoped, so no one is unexpectedly locked out until they next log in.

7 new tests covering: BDA-to-BDA isolation, admin sees everyone, unassigned leads stay visible to all (including the broken-shape Mongoose-default calendlyHost), ids endpoint parity, analytics count isolation, and a bdaEmail query-param bypass attempt.