### PR TITLE
Send booking link, not stale reschedule link, in not-scheduled meta templates

### DIFF
--- a/Utils/TemplateParameterBuilder.js
+++ b/Utils/TemplateParameterBuilder.js
@@ -142,6 +142,19 @@ async function resolveRescheduleLink(booking) {
 }
 
 /**
+ * Shared builder for the not-scheduled meta_* templates:
+ * {{1}} = client name, {{2}} = booking link.
+ */
+async function metaSchedulingParams({ booking, step }) {
+  const schedulingLink = step?.templateConfig?.schedulingLink || DEFAULT_SCHEDULING_LINK;
+
+  return [
+    booking.clientName || 'Valued Client',
+    schedulingLink
+  ];
+}
+
+/**
  * Template parameter builder registry.
  * Each builder takes { booking, step, executedAt } and returns an array of parameter values.
  */
@@ -186,49 +199,16 @@ const builders = {
     ];
   },
 
-  meta_1: async ({ booking, step }) => {
-    const schedulingLink = step?.templateConfig?.schedulingLink
-      || booking.calendlyRescheduleLink
-      || DEFAULT_SCHEDULING_LINK;
-
-    return [
-      booking.clientName || 'Valued Client',
-      schedulingLink
-    ];
-  },
-
-  meta_2: async ({ booking, step }) => {
-    const schedulingLink = step?.templateConfig?.schedulingLink
-      || booking.calendlyRescheduleLink
-      || DEFAULT_SCHEDULING_LINK;
-
-    return [
-      booking.clientName || 'Valued Client',
-      schedulingLink
-    ];
-  },
-
-  meta_31: async ({ booking, step }) => {
-    const schedulingLink = step?.templateConfig?.schedulingLink
-      || booking.calendlyRescheduleLink
-      || DEFAULT_SCHEDULING_LINK;
-
-    return [
-      booking.clientName || 'Valued Client',
-      schedulingLink
-    ];
-  },
-
-  meta_41: async ({ booking, step }) => {
-    const schedulingLink = step?.templateConfig?.schedulingLink
-      || booking.calendlyRescheduleLink
-      || DEFAULT_SCHEDULING_LINK;
-
-    return [
-      booking.clientName || 'Valued Client',
-      schedulingLink
-    ];
-  },
+  // meta_* templates run in the not-scheduled workflow: the client has no active
+  // upcoming meeting (status change to scheduled cancels these steps), so they must
+  // always get a fresh BOOKING link. Never fall back to booking.calendlyRescheduleLink —
+  // for a returning client (completed meeting, re-filled the form) that field still
+  // holds the old event's reschedule link and would invite them to reschedule a
+  // finished meeting instead of booking a new one.
+  meta_1: metaSchedulingParams,
+  meta_2: metaSchedulingParams,
+  meta_31: metaSchedulingParams,
+  meta_41: metaSchedulingParams,
 
   cancelled1: async ({ booking }) => {
     if (!booking.scheduledEventStartTime) {


### PR DESCRIPTION
## Problem

A completed client who re-fills the meta lead form re-triggers the not-scheduled workflow on their existing booking. The day-0 WhatsApp message ("you can schedule your consultation here: ...") then sent the **old meeting's Calendly reschedule link** instead of the booking link — inviting them to reschedule a finished event.

Real case: Het Patel (`booking_1783881275929_6pyhuhyf6`, status `completed`, meeting Jul 14) re-filled on Jul 22; the day-0 `meta_1` send delivered `calendly.com/reschedulings/7506b370-...` from the completed meeting.

## Cause

The `meta_1/2/31/41` builders in `Utils/TemplateParameterBuilder.js` resolved the link as:

```js
step?.templateConfig?.schedulingLink || booking.calendlyRescheduleLink || DEFAULT_SCHEDULING_LINK
```

Fresh leads have no `calendlyRescheduleLink`, so this worked by luck. A returning client's booking still carries the stale link, which wins the chain.

## Fix

The not-scheduled workflow only runs when the client has no active upcoming meeting (a status change to scheduled cancels these steps), so a reschedule link is never correct in this context. The builders now use `step override || DEFAULT_SCHEDULING_LINK`, and the four duplicates are consolidated into one shared `metaSchedulingParams` with a comment explaining why the reschedule fallback must not return.

## Verified

- All four meta templates return the booking link even when the booking has a stale `calendlyRescheduleLink`.
- Per-step `templateConfig.schedulingLink` override still wins.
- `cancelled1` and appointment reminder templates (active-meeting context, where the reschedule link IS correct) are untouched.
- Covers both send paths — immediate day-0 sends (WorkflowController) and cron-scheduled sends (cronScheduler) share this builder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)