### PR TITLE
Add Mongo timeout resilience to Calendly webhook handler

### DIFF
--- a/Controllers/CalendlyWebhookController.js
+++ b/Controllers/CalendlyWebhookController.js
@@ -15,6 +15,7 @@ import {
 import { cancelDiscordMeetRemindersForMeeting, scheduleDiscordMeetReminder } from '../Utils/DiscordMeetReminderScheduler.js';
 import { getRescheduleLinkForBooking, resolveCalendlyHost } from '../Utils/CalendlyAPIHelper.js';
 import { CrmUserModel } from '../Schema_Models/CrmUser.js';
+import { withMongoRetry } from '../Utils/withMongoRetry.js';
 
 /**
  * One-line "Assigned BDA" label for Discord messages. Prefers the Calendly
@@ -136,6 +137,21 @@ export const handleCalendlyWebhook = async (req, res) => {
       stack: error.stack,
       body: req.body
     });
+
+    // Best-effort alert so the team still hears about a booking even when the
+    // DB write itself failed (e.g. transient Mongo timeout) — a failure here
+    // must never mask the original error response below. Posted to the same
+    // channel as successful bookings (#new-meetings-calendly) so failures are
+    // visible right next to normal booking activity.
+    if (process.env.DISCORD_MEET_WEB_HOOK_URL) {
+      const payload = req.body?.payload;
+      const inviteeName = payload?.invitee?.name || payload?.name || 'Unknown';
+      const inviteeEmail = payload?.invitee?.email || payload?.email || 'Unknown';
+      const meetingStart = payload?.scheduled_event?.start_time || 'Unknown';
+      DiscordConnectForMeet(
+        `⚠️ Calendly webhook processing FAILED (${error.message}). Booking may be missing from DB — please check manually.\nName: ${inviteeName}\nEmail: ${inviteeEmail}\nMeeting start: ${meetingStart}`
+      ).catch(discordErr => Logger.warn('Failed to send webhook-failure Discord alert', { error: discordErr.message }));
+    }
 
     res.status(500).json({
       success: false,
@@ -308,11 +324,11 @@ async function handleCreatedEvent(req, res, payload) {
     scheduledEventStartTime: scheduledStartISO,
     $or: duplicateOr,
   };
-  const existingBooking = await CampaignBookingModel.findOne(duplicateQuery);
+  const existingBooking = await withMongoRetry(() => CampaignBookingModel.findOne(duplicateQuery));
 
   // Same invitee URI already stored = Calendly retry or duplicate delivery
   if (inviteeUri) {
-    const uriAlready = await CampaignBookingModel.findOne({ calendlyInviteeUri: inviteeUri }).lean();
+    const uriAlready = await withMongoRetry(() => CampaignBookingModel.findOne({ calendlyInviteeUri: inviteeUri }).lean());
     if (uriAlready) {
       Logger.warn('Duplicate invitee.created — calendlyInviteeUri already in DB', { inviteeUri });
       return res.status(200).json({
@@ -387,7 +403,7 @@ async function handleCreatedEvent(req, res, payload) {
   if (inviteeUri) {
     calendlyDedupeKey = `invitee.created:${inviteeUri}`;
     try {
-      await CalendlyWebhookDedupeModel.create({ key: calendlyDedupeKey });
+      await withMongoRetry(() => CalendlyWebhookDedupeModel.create({ key: calendlyDedupeKey }));
     } catch (e) {
       if (e.code === 11000) {
         Logger.warn('Calendly invitee.created duplicate delivery suppressed', { inviteeUri });
@@ -403,7 +419,7 @@ async function handleCreatedEvent(req, res, payload) {
 
   let newBooking = null;
   if (shouldMergeIntoExisting) {
-    newBooking = await CampaignBookingModel.findOneAndUpdate(
+    newBooking = await withMongoRetry(() => CampaignBookingModel.findOneAndUpdate(
       { bookingId: existingBooking.bookingId },
       {
         $set: {
@@ -430,7 +446,7 @@ async function handleCreatedEvent(req, res, payload) {
         }
       },
       { new: true }
-    );
+    ));
     Logger.info(
       rebookedSameSlot
         ? '✅ Merged Calendly invitee.created into existing booking (cancel+rebook)'
@@ -740,7 +756,7 @@ async function handleCreatedEvent(req, res, payload) {
     ...(calendlyHost ? { calendlyHost } : {})
   });
 
-  await newBooking.save();
+  await withMongoRetry(() => newBooking.save());
 
   // Resolve the real meet.google.com code behind Calendly's join_url redirect
   // NOW, so the extension can match the Meet tab the moment the BDA joins

--- a/Utils/ConnectDB.js
+++ b/Utils/ConnectDB.js
@@ -11,15 +11,41 @@ import dotenv from "dotenv";
 
 dotenv.config();
 
-const Connection = () => mongoose.connect(process.env.MONGODB_URI, {
+mongoose.connection.on("connected", () => {
+  console.log("[MongoDB] connected");
+});
+
+mongoose.connection.on("error", (err) => {
+  console.error("[MongoDB] connection error", err);
+});
+
+mongoose.connection.on("disconnected", () => {
+  console.warn("[MongoDB] disconnected — mongoose will auto-retry using bufferCommands/retry options");
+});
+
+mongoose.connection.on("reconnected", () => {
+  console.log("[MongoDB] reconnected");
+});
+
+const connectWithRetry = (retryDelayMs = 5000) => {
+  mongoose.connect(process.env.MONGODB_URI, {
     maxPoolSize: 50,
     minPoolSize: 10,
     maxIdleTimeMS: 60000,
-    serverSelectionTimeoutMS: 5000,
-    socketTimeoutMS: 20000,
-    connectTimeoutMS: 10000,
+    serverSelectionTimeoutMS: 10000,
+    socketTimeoutMS: 45000,
+    connectTimeoutMS: 15000,
+    retryWrites: true,
+    retryReads: true,
   })
     .then(() => console.log("Database connected successfully..!"))
-    .catch((e) => console.log('Problem while connecting to db', e));
+    .catch((e) => {
+      console.log("Problem while connecting to db", e);
+      console.log(`[MongoDB] retrying connection in ${retryDelayMs / 1000}s`);
+      setTimeout(() => connectWithRetry(retryDelayMs), retryDelayMs);
+    });
+};
+
+const Connection = () => connectWithRetry();
 
 export default Connection;

--- a/Utils/withMongoRetry.js
+++ b/Utils/withMongoRetry.js
@@ -1,0 +1,36 @@
+const RETRYABLE_ERROR_NAMES = new Set([
+  'MongoNetworkTimeoutError',
+  'MongoNetworkError',
+  'MongoServerSelectionError',
+  'MongoTimeoutError',
+]);
+
+function isRetryableMongoError(err) {
+  if (!err) return false;
+  if (RETRYABLE_ERROR_NAMES.has(err.name)) return true;
+  if (err.errorLabelSet?.has?.('RetryableWriteError')) return true;
+  return false;
+}
+
+/**
+ * Retries a Mongo operation on transient network/timeout errors with short backoff.
+ * Calendly expects a response within ~10-20s, so total retry time is kept small
+ * (default 3 attempts, ~4.5s max added delay) rather than trying to ride out a
+ * multi-minute Atlas outage inline.
+ */
+export async function withMongoRetry(fn, { attempts = 3, baseDelayMs = 750 } = {}) {
+  let lastErr;
+  for (let attempt = 1; attempt <= attempts; attempt++) {
+    try {
+      return await fn();
+    } catch (err) {
+      lastErr = err;
+      if (!isRetryableMongoError(err) || attempt === attempts) {
+        throw err;
+      }
+      const delay = baseDelayMs * attempt;
+      await new Promise((resolve) => setTimeout(resolve, delay));
+    }
+  }
+  throw lastErr;
+}


### PR DESCRIPTION
## Summary
- Fixes a real incident: MongoDB Atlas had a ~8 minute network blip on 2026-07-31 (19:31-19:39 UTC), causing a Calendly `invitee.created` webhook to fail repeatedly (7 retries from Calendly). The booking never got saved and the Discord notification never fired, because it only runs *after* the DB writes succeed — so the team had zero visibility into a real, missed booking.
- `Utils/withMongoRetry.js` (new): retries only genuinely transient Mongo errors (`MongoNetworkTimeoutError`, `MongoNetworkError`, `MongoServerSelectionError`, `MongoTimeoutError`, driver-flagged `RetryableWriteError`) up to 3x with backoff. Non-retryable errors (validation, duplicate keys) still fail immediately as before.
- `Utils/ConnectDB.js`: adds `connected`/`error`/`disconnected`/`reconnected` event logging (there was none), retry-with-backoff if the initial connect fails (previously it just logged once and gave up), and slightly wider timeouts (`serverSelectionTimeoutMS` 5s→10s, `socketTimeoutMS` 20s→45s, `connectTimeoutMS` 10s→15s) plus `retryWrites`/`retryReads`.
- `Controllers/CalendlyWebhookController.js`: wraps the 5 critical booking DB calls (duplicate checks, dedupe-key create, merge update, booking save) with `withMongoRetry`, and the outer catch now posts a Discord alert to `#new-meetings-calendly` (same channel as normal booking confirmations) whenever webhook processing fails for any reason — so a dropped booking is never silent again.

## Test plan
- [x] `node --check` passes on all three files
- [x] Verified `withMongoRetry` behavior directly: retries transient errors and succeeds once they clear, fails immediately on non-retryable errors, exhausts retries and throws on persistent failure
- [x] Sent a live test POST to the production Discord webhooks used by the new failure-alert path (`DISCORD_MEET_WEB_HOOK_URL`) — confirmed delivery (HTTP 204) and visually confirmed the message appeared correctly in `#new-meetings-calendly`
- [ ] Manually verify in staging/production logs after deploy that a real Mongo blip (if one recurs) now results in a Discord alert instead of silence

🤖 Generated with [Claude Code](https://claude.com/claude-code)