### PR TITLE
fix: filter BDA breakdown by scheduledEventStartTime only

### DIFF
--- a/Controllers/Graphs03Controller.js
+++ b/Controllers/Graphs03Controller.js
@@ -747,10 +747,7 @@ export const getBdaStatusBreakdown = async (req, res) => {
       {
         $match: {
           bookingStatus: { $in: ['completed', 'paid', 'no-show', 'rescheduled', 'canceled', 'scheduled', 'not-scheduled', 'ignored'] },
-          $or: [
-            { scheduledEventStartTime: { $gte: from, $lte: to } },
-            { bookingCreatedAt: { $gte: from, $lte: to } },
-          ],
+          scheduledEventStartTime: { $gte: from, $lte: to },
         },
       },
       OWNER_EMAILS_STAGE,


### PR DESCRIPTION
## Problem
The `$or` on `scheduledEventStartTime OR bookingCreatedAt` was pulling in old bookings created before the selected date range, inflating counts badly — e.g. Cancelled showed 120 for July when the dashboard shows 55.

## Fix
Filter strictly on `scheduledEventStartTime` so "assigned in range" = meetings that were **scheduled to happen** in that period. This matches how the dashboard chart buckets meetings and makes the numbers directly comparable.

## Verified
- Dashboard Jul 2026: Cancelled 55, No-Show 91, Completed 135
- After fix, BDA breakdown for Jul 1–31 should align with those totals across all BDAs

🤖 Generated with [Claude Code](https://claude.com/claude-code)