### PR TITLE
Add multi-region payment links and short URL redirects

### DIFF
--- a/Controllers/PaymentLinkController.js
+++ b/Controllers/PaymentLinkController.js
@@ -1,29 +1,81 @@
 import Stripe from 'stripe';
+import crypto from 'crypto';
+import { ShortLinkModel } from '../Schema_Models/ShortLink.js';
 
 const stripe = new Stripe(process.env.STRIPE_SECRET_KEY);
 
-const PLANS = {
-  professional: {
-    name: 'Professional Plan – Mid-Level Professionals',
-    description: 'Once your payment is confirmed, you will receive an official invoice via email. Our team will initiate the onboarding process within 24 hours, providing you with access credentials and clear next steps. Dedicated 24/7 support will be available throughout your journey.',
-    originalPrice: 349,
+const SHORT_CODE_ALPHABET = 'ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz23456789';
+
+function generateShortCode(length = 7) {
+  const bytes = crypto.randomBytes(length);
+  let code = '';
+  for (let i = 0; i < length; i++) {
+    code += SHORT_CODE_ALPHABET[bytes[i] % SHORT_CODE_ALPHABET.length];
+  }
+  return code;
+}
+
+async function createShortLink(longUrl, expiresAtSeconds, createdBy) {
+  const shortLinkBase = process.env.SHORT_LINK_BASE_URL || 'https://api.flashfirejobs.com';
+
+  for (let attempt = 0; attempt < 5; attempt++) {
+    const code = generateShortCode();
+    try {
+      await ShortLinkModel.create({
+        code,
+        longUrl,
+        createdBy,
+        expiresAt: new Date(expiresAtSeconds * 1000),
+      });
+      return `${shortLinkBase}/s/${code}`;
+    } catch (err) {
+      if (err?.code === 11000) continue; // code collision, retry
+      throw err;
+    }
+  }
+  throw new Error('Unable to generate a unique short code.');
+}
+
+const PLAN_DESCRIPTION = 'Once your payment is confirmed, you will receive an official invoice via email. Our team will initiate the onboarding process within 24 hours, providing you with access credentials and clear next steps. Dedicated 24/7 support will be available throughout your journey.';
+
+const REGIONS = {
+  us: {
+    currency: 'usd',
+    plans: {
+      professional: { name: 'Professional Plan – Mid-Level Professionals', originalPrice: 349 },
+      executive: { name: 'Executive Plan – 1200+ Applications', originalPrice: 599 },
+    },
   },
-  executive: {
-    name: 'Executive Plan – 1200+ Applications',
-    description: 'Once your payment is confirmed, you will receive an official invoice via email. Our team will initiate the onboarding process within 24 hours, providing you with access credentials and clear next steps. Dedicated 24/7 support will be available throughout your journey.',
-    originalPrice: 599,
+  uk: {
+    currency: 'gbp',
+    plans: {
+      professional: { name: 'Professional Plan – Mid-Level Professionals', originalPrice: 299 },
+      executive: { name: 'Executive Plan – 1200+ Applications', originalPrice: 499 },
+    },
+  },
+  ca: {
+    currency: 'cad',
+    plans: {
+      professional: { name: 'Professional Plan – Mid-Level Professionals', originalPrice: 409 },
+      executive: { name: 'Executive Plan – 1200+ Applications', originalPrice: 799 },
+    },
   },
 };
 
 export async function generatePaymentLink(req, res) {
   try {
     const { plan, discount } = req.body;
+    const region = REGIONS[req.body.region || 'us'];
 
-    if (!plan || !PLANS[plan]) {
+    if (!region) {
+      return res.status(400).json({ success: false, error: 'Invalid region selected.' });
+    }
+
+    if (!plan || !region.plans[plan]) {
       return res.status(400).json({ success: false, error: 'Invalid plan selected.' });
     }
 
-    const planConfig = PLANS[plan];
+    const planConfig = region.plans[plan];
     const discountAmount = Number(discount);
 
     if (isNaN(discountAmount) || discountAmount < 0) {
@@ -37,21 +89,21 @@ export async function generatePaymentLink(req, res) {
     }
 
     const baseUrl = process.env.CAMPAIGN_BASE_URL || 'https://www.flashfirejobs.com';
-    const expiresAt = Math.floor(Date.now() / 1000) + 12 * 60 * 60;
+    const expiresAt = Math.floor(Date.now() / 1000) + 5 * 60 * 60;
 
     const session = await stripe.checkout.sessions.create({
       mode: 'payment',
-      currency: 'usd',
+      currency: region.currency,
       customer_creation: 'always',
       invoice_creation: { enabled: true },
       line_items: [
         {
           price_data: {
-            currency: 'usd',
+            currency: region.currency,
             unit_amount: Math.round(finalPrice * 100),
             product_data: {
               name: planConfig.name,
-              description: planConfig.description,
+              description: PLAN_DESCRIPTION,
             },
           },
           quantity: 1,
@@ -62,9 +114,17 @@ export async function generatePaymentLink(req, res) {
       cancel_url: `${baseUrl}/payment-cancelled`,
     });
 
+    let shortUrl = null;
+    try {
+      shortUrl = await createShortLink(session.url, session.expires_at, req.crmUser?.email || req.crmUser?.id);
+    } catch (shortLinkErr) {
+      console.error('[PaymentLinkController] Short link creation failed:', shortLinkErr);
+    }
+
     return res.json({
       success: true,
-      url: session.url,
+      url: shortUrl || session.url,
+      stripeUrl: session.url,
       sessionId: session.id,
       finalPrice,
       expiresAt: session.expires_at,
@@ -72,5 +132,25 @@ export async function generatePaymentLink(req, res) {
   } catch (err) {
     console.error('[PaymentLinkController] Error:', err);
     return res.status(500).json({ success: false, error: 'Unable to connect to Stripe. Please try again.' });
+  }
+}
+
+export async function redirectShortLink(req, res) {
+  try {
+    const { code } = req.params;
+    const link = await ShortLinkModel.findOne({ code });
+
+    if (!link) {
+      return res.status(404).send('This link is invalid or has expired.');
+    }
+
+    if (link.expiresAt.getTime() < Date.now()) {
+      return res.status(410).send('This payment link has expired. Please request a new one.');
+    }
+
+    return res.redirect(302, link.longUrl);
+  } catch (err) {
+    console.error('[PaymentLinkController] Redirect error:', err);
+    return res.status(500).send('Something went wrong. Please try again.');
   }
 }

--- a/Routes.js
+++ b/Routes.js
@@ -156,7 +156,7 @@ import { getActivityLogs, getActivityFilters } from './Controllers/ActivityLogCo
 import { getPaidClientsAnalytics } from './Controllers/PaidClientsController.js';
 import { getStripePaymentsByMonth, getStripeAllMonthsSummary, getStripePaidPlanMonthlySummary } from './Controllers/StripeDataController.js';
 import { getManualPaymentsByMonth, createManualPayment, updateManualPayment, deleteManualPayment } from './Controllers/ManualPaymentController.js';
-import { generatePaymentLink } from './Controllers/PaymentLinkController.js';
+import { generatePaymentLink, redirectShortLink } from './Controllers/PaymentLinkController.js';
 import { listMySessions, revokeMySession, listAllSessions, adminRevokeSession } from './Controllers/CrmSessionController.js';
 import {
   listDesignedTemplates,
@@ -301,6 +301,8 @@ export default function Routes(app) {
 
   // Payment Link Generator — BDA internal tool
   app.post('/api/crm/generate-payment-link', requireCrmUser, requireCrmPermission('payment_links'), generatePaymentLink);
+  // Public short-link redirect for generated payment links.
+  app.get('/s/:code', redirectShortLink);
 
   // Zoom Phone — webhook is public (HMAC-verified inside).
   app.post('/api/zoom-phone/webhook', zoomPhoneWebhook);

--- a/Schema_Models/ShortLink.js
+++ b/Schema_Models/ShortLink.js
@@ -1,0 +1,10 @@
+import mongoose from 'mongoose';
+
+const ShortLinkSchema = new mongoose.Schema({
+  code: { type: String, required: true, unique: true, index: true },
+  longUrl: { type: String, required: true },
+  createdBy: { type: String },
+  expiresAt: { type: Date, required: true },
+}, { timestamps: true });
+
+export const ShortLinkModel = mongoose.model('ShortLink', ShortLinkSchema);


### PR DESCRIPTION
## Summary
- Payment Link Generator now supports US (USD), UK (GBP), and Canada (CAD) regions with region-specific Professional/Executive pricing, matching the tiers live on the marketing site
- Stripe checkout session expiry reduced from 12h to 5h
- Generated payment links are now wrapped in a short, shareable URL (`api.flashfirejobs.com/s/<code>`) via a new `ShortLink` Mongo model + public `GET /s/:code` redirect route, since raw Stripe checkout URLs were too long to share with clients
- Falls back to the raw Stripe URL if short-link creation fails, so link generation never breaks

## Test plan
- [x] Ran locally against live Stripe + production Mongo: generated a link, confirmed short URL 302-redirects to the correct Stripe checkout session, confirmed unknown codes return 404
- [ ] Confirm `SHORT_LINK_BASE_URL` env var is set correctly in deployment (defaults to `https://api.flashfirejobs.com`)
- [ ] Verify `/s/:code` route doesn't conflict with any reverse-proxy/static routing in production

🤖 Generated with [Claude Code](https://claude.com/claude-code)