### PR TITLE
Extend payment link expiry to 6 hours

### DIFF
--- a/Controllers/PaymentLinkController.js
+++ b/Controllers/PaymentLinkController.js
@@ -89,7 +89,7 @@ export async function generatePaymentLink(req, res) {
     }
 
     const baseUrl = process.env.CAMPAIGN_BASE_URL || 'https://www.flashfirejobs.com';
-    const expiresAt = Math.floor(Date.now() / 1000) + 5 * 60 * 60;
+    const expiresAt = Math.floor(Date.now() / 1000) + 6 * 60 * 60;
 
     const session = await stripe.checkout.sessions.create({
       mode: 'payment',


### PR DESCRIPTION
## Summary
- Follow-up to #196: extends the generated payment link expiry from 5 to 6 hours per request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)