### PR TITLE
feat: add GBP currency support for BDA incentive config

### DIFF
--- a/Controllers/BdaIncentiveController.js
+++ b/Controllers/BdaIncentiveController.js
@@ -1,35 +1,44 @@
 import { BdaIncentiveConfigModel } from '../Schema_Models/BdaIncentiveConfig.js';
 
-const PLAN_CATALOG = {
-  PRIME: { price: 99, currency: 'USD' },
-  IGNITE: { price: 199, currency: 'USD' },
-  PROFESSIONAL: { price: 349, currency: 'USD' },
-  EXECUTIVE: { price: 599, currency: 'USD' }
+const PLAN_NAMES = ['PRIME', 'IGNITE', 'PROFESSIONAL', 'EXECUTIVE'];
+
+// Default base prices per currency — matches live pricing pages
+const CURRENCY_DEFAULTS = {
+  USD: { PRIME: 99,  IGNITE: 199, PROFESSIONAL: 349, EXECUTIVE: 599 },
+  CAD: { PRIME: 139, IGNITE: 239, PROFESSIONAL: 409, EXECUTIVE: 799 },
+  GBP: { PRIME: 79,  IGNITE: 149, PROFESSIONAL: 299, EXECUTIVE: 499 },
 };
 
 export const getIncentiveConfig = async (req, res) => {
   try {
     const existing = await BdaIncentiveConfigModel.find({}).lean();
+
+    // Build map keyed by "planName|currency"
     const map = new Map();
     existing.forEach((c) => {
-      map.set(c.planName, c);
+      const currency = c.currency || 'USD';
+      // Support legacy rows that only have basePriceUsd and no currency field
+      const basePrice = c.basePrice != null ? c.basePrice : (c.basePriceUsd ?? null);
+      map.set(`${c.planName}|${currency}`, { ...c, basePrice, currency });
     });
 
-    const configs = Object.keys(PLAN_CATALOG).map((planName) => {
-      const base = PLAN_CATALOG[planName];
-      const row = map.get(planName);
-      return {
-        planName,
-        basePriceUsd: row?.basePriceUsd != null ? row.basePriceUsd : base.price,
-        currency: base.currency,
-        incentivePerLeadInr: row?.incentivePerLeadInr != null ? row.incentivePerLeadInr : 0
-      };
-    });
+    const configs = [];
+    for (const [currency, defaults] of Object.entries(CURRENCY_DEFAULTS)) {
+      for (const planName of PLAN_NAMES) {
+        const key = `${planName}|${currency}`;
+        const row = map.get(key);
+        configs.push({
+          planName,
+          currency,
+          basePrice: row?.basePrice != null ? row.basePrice : defaults[planName],
+          // Legacy field for backward compat
+          basePriceUsd: currency === 'USD' ? (row?.basePrice ?? defaults[planName]) : undefined,
+          incentivePerLeadInr: row?.incentivePerLeadInr ?? 0
+        });
+      }
+    }
 
-    return res.status(200).json({
-      success: true,
-      configs
-    });
+    return res.status(200).json({ success: true, configs });
   } catch (error) {
     return res.status(500).json({
       success: false,
@@ -44,48 +53,36 @@ export const saveIncentiveConfig = async (req, res) => {
     const { configs } = req.body;
 
     if (!Array.isArray(configs)) {
-      return res.status(400).json({
-        success: false,
-        message: 'configs array is required'
-      });
+      return res.status(400).json({ success: false, message: 'configs array is required' });
     }
 
     for (const cfg of configs) {
       const planName = cfg.planName;
-      if (!PLAN_CATALOG[planName]) {
-        continue;
-      }
-      const basePriceUsd = cfg.basePriceUsd != null ? Number(cfg.basePriceUsd) : null;
-      const incentivePerLeadInr = cfg.incentivePerLeadInr != null ? Number(cfg.incentivePerLeadInr) : 0;
-      if (basePriceUsd != null && (Number.isNaN(basePriceUsd) || basePriceUsd < 0)) {
-        continue;
-      }
-      if (Number.isNaN(incentivePerLeadInr) || incentivePerLeadInr < 0) {
-        continue;
-      }
+      if (!PLAN_NAMES.includes(planName)) continue;
 
-      const update = {
-        updatedAt: new Date(),
-        incentivePerLeadInr
-      };
-      if (basePriceUsd != null) {
-        update.basePriceUsd = basePriceUsd;
+      const currency = (cfg.currency || 'USD').toUpperCase();
+      // Accept either basePrice or legacy basePriceUsd
+      const basePrice = cfg.basePrice != null ? Number(cfg.basePrice) : (cfg.basePriceUsd != null ? Number(cfg.basePriceUsd) : null);
+      const incentivePerLeadInr = cfg.incentivePerLeadInr != null ? Number(cfg.incentivePerLeadInr) : 0;
+
+      if (basePrice != null && (Number.isNaN(basePrice) || basePrice < 0)) continue;
+      if (Number.isNaN(incentivePerLeadInr) || incentivePerLeadInr < 0) continue;
+
+      const update = { updatedAt: new Date(), currency, incentivePerLeadInr };
+      if (basePrice != null) {
+        update.basePrice = basePrice;
+        if (currency === 'USD') update.basePriceUsd = basePrice;
       }
 
       await BdaIncentiveConfigModel.findOneAndUpdate(
-        { planName },
+        { planName, currency },
         update,
         { upsert: true, new: true }
       );
     }
 
     const updated = await BdaIncentiveConfigModel.find({}).lean();
-
-    return res.status(200).json({
-      success: true,
-      message: 'Incentive config saved',
-      data: updated
-    });
+    return res.status(200).json({ success: true, message: 'Incentive config saved', data: updated });
   } catch (error) {
     return res.status(500).json({
       success: false,

--- a/Controllers/BdaLeadController.js
+++ b/Controllers/BdaLeadController.js
@@ -6,54 +6,44 @@ import { sendBdaClaimApprovalEmail } from '../Utils/SendGridHelper.js';
 import { currencySymbol } from '../Utils/currency.js';
 import crypto from 'crypto';
 
-// Current plan prices (fallback when basePriceUsd not in DB). Admin can override via BdaIncentiveConfig.basePriceUsd.
-const PLAN_CATALOG = {
-  PRIME: { price: 99 },
-  IGNITE: { price: 199 },
-  PROFESSIONAL: { price: 349 },
-  EXECUTIVE: { price: 599 }
-};
-
-// Default CAD base prices (matching frontend defaults)
-const CAD_BASE_PRICES = {
-  PRIME: 139,
-  IGNITE: 239,
-  PROFESSIONAL: 409,
-  EXECUTIVE: 799
+// Fallback base prices per currency when not yet configured in DB
+const CURRENCY_BASE_PRICES = {
+  USD: { PRIME: 99,  IGNITE: 199, PROFESSIONAL: 349, EXECUTIVE: 599 },
+  CAD: { PRIME: 139, IGNITE: 239, PROFESSIONAL: 409, EXECUTIVE: 799 },
+  GBP: { PRIME: 79,  IGNITE: 149, PROFESSIONAL: 299, EXECUTIVE: 499 },
 };
 
 const BDA_ALLOWED_LEAD_STATUSES = ['paid', 'scheduled', 'completed', 'rescheduled'];
 
-/** Compute prorated incentive (INR) for one line. configByPlan: Map(planName -> { basePriceUsd, incentivePerLeadInr }). */
-function incentiveForLine(configByPlan, planName, amount, currency) {
+/**
+ * Compute prorated incentive (INR) for one line.
+ * configByKey: Map("planName|CURRENCY" -> { basePrice, incentivePerLeadInr })
+ */
+function incentiveForLine(configByKey, planName, amount, currency) {
   if (!planName || !amount || amount <= 0) return 0;
-  const config = configByPlan.get(planName);
+  const cur = (currency || 'USD').toUpperCase();
+  const key = `${planName}|${cur}`;
+  const config = configByKey.get(key) || configByKey.get(`${planName}|USD`);
   if (!config) return 0;
-  
-  // Use currency-specific base price if CAD, otherwise use USD base price
-  let base;
-  if (currency && currency.toUpperCase() === 'CAD') {
-    base = CAD_BASE_PRICES[planName] || PLAN_CATALOG[planName]?.price || 1;
-  } else {
-    base = config.basePriceUsd > 0 ? config.basePriceUsd : (PLAN_CATALOG[planName]?.price ?? 1);
-  }
-  
+
+  const fallback = (CURRENCY_BASE_PRICES[cur] || CURRENCY_BASE_PRICES.USD)[planName] || 1;
+  const base = config.basePrice > 0 ? config.basePrice : fallback;
   const ratio = Math.min(1, amount / base);
   return config.incentivePerLeadInr * ratio;
 }
 
 /** Total incentive (INR) for a paid booking: from paymentBreakdown (sum per line) or single paymentPlan. */
-function incentiveForBooking(configByPlan, booking) {
+function incentiveForBooking(configByKey, booking) {
   if (Array.isArray(booking.paymentBreakdown) && booking.paymentBreakdown.length > 0) {
     return booking.paymentBreakdown.reduce(
-      (sum, line) => sum + incentiveForLine(configByPlan, line.planName, line.amount, line.currency),
+      (sum, line) => sum + incentiveForLine(configByKey, line.planName, line.amount, line.currency),
       0
     );
   }
   const planName = booking.paymentPlan?.name;
   const amount = Number(booking.paymentPlan?.price);
   const currency = booking.paymentPlan?.currency || 'USD';
-  return incentiveForLine(configByPlan, planName, amount, currency);
+  return incentiveForLine(configByKey, planName, amount, currency);
 }
 
 export const getAvailableLeads = async (req, res) => {
@@ -519,19 +509,18 @@ export const getBdaAnalysis = async (req, res) => {
     );
 
     const incentiveRows = await BdaIncentiveConfigModel.find({}).lean();
-    const configByPlan = new Map();
+    const configByKey = new Map();
     incentiveRows.forEach((r) => {
-      configByPlan.set(r.planName, {
-        basePriceUsd: r.basePriceUsd != null ? r.basePriceUsd : (PLAN_CATALOG[r.planName]?.price ?? 0),
-        incentivePerLeadInr: r.incentivePerLeadInr != null ? r.incentivePerLeadInr : 0
-      });
+      const currency = (r.currency || 'USD').toUpperCase();
+      const basePrice = r.basePrice != null ? r.basePrice : (r.basePriceUsd ?? (CURRENCY_BASE_PRICES.USD[r.planName] ?? 0));
+      configByKey.set(`${r.planName}|${currency}`, { basePrice, incentivePerLeadInr: r.incentivePerLeadInr ?? 0 });
     });
 
     const incentiveByBda = new Map();
     for (const b of approvedPaidBookingsForIncentive) {
       const email = b.claimedBy?.email;
       if (!email) continue;
-      const inc = incentiveForBooking(configByPlan, b);
+      const inc = incentiveForBooking(configByKey, b);
       if (inc > 0) incentiveByBda.set(email, (incentiveByBda.get(email) ?? 0) + inc);
     }
 
@@ -671,16 +660,15 @@ export const getMyClaimedLeads = async (req, res) => {
     );
 
     const incentiveRows = await BdaIncentiveConfigModel.find({}).lean();
-    const configByPlan = new Map();
+    const configByKey = new Map();
     incentiveRows.forEach((r) => {
-      configByPlan.set(r.planName, {
-        basePriceUsd: r.basePriceUsd != null ? r.basePriceUsd : (PLAN_CATALOG[r.planName]?.price ?? 0),
-        incentivePerLeadInr: r.incentivePerLeadInr != null ? r.incentivePerLeadInr : 0
-      });
+      const currency = (r.currency || 'USD').toUpperCase();
+      const basePrice = r.basePrice != null ? r.basePrice : (r.basePriceUsd ?? (CURRENCY_BASE_PRICES.USD[r.planName] ?? 0));
+      configByKey.set(`${r.planName}|${currency}`, { basePrice, incentivePerLeadInr: r.incentivePerLeadInr ?? 0 });
     });
     let totalIncentivesForFilter = 0;
     for (const b of approvedPaidBookings) {
-      totalIncentivesForFilter += incentiveForBooking(configByPlan, b);
+      totalIncentivesForFilter += incentiveForBooking(configByKey, b);
     }
 
     return res.status(200).json({

--- a/Schema_Models/BdaIncentiveConfig.js
+++ b/Schema_Models/BdaIncentiveConfig.js
@@ -5,9 +5,20 @@ const BdaIncentiveConfigSchema = new mongoose.Schema(
     planName: {
       type: String,
       enum: ['PRIME', 'IGNITE', 'PROFESSIONAL', 'EXECUTIVE'],
-      required: true,
-      unique: true
+      required: true
     },
+    currency: {
+      type: String,
+      enum: ['USD', 'CAD', 'GBP', 'EUR', 'INR'],
+      required: true,
+      default: 'USD'
+    },
+    basePrice: {
+      type: Number,
+      default: null,
+      min: 0
+    },
+    // Legacy field kept for backward compatibility
     basePriceUsd: {
       type: Number,
       default: null,
@@ -25,6 +36,8 @@ const BdaIncentiveConfigSchema = new mongoose.Schema(
   },
   { timestamps: true }
 );
+
+BdaIncentiveConfigSchema.index({ planName: 1, currency: 1 }, { unique: true });
 
 export const BdaIncentiveConfigModel =
   mongoose.models.BdaIncentiveConfig || mongoose.model('BdaIncentiveConfig', BdaIncentiveConfigSchema);


### PR DESCRIPTION
## Summary
- **Schema** (`BdaIncentiveConfig`): adds `currency` field + compound unique index on `{planName, currency}`; new `basePrice` field (old `basePriceUsd` kept for backward compat with existing USD rows)
- **BdaIncentiveController**: GET now returns rows for all currencies (USD/CAD/GBP); PUT saves by `{planName, currency}`; default GBP prices match live UK pricing page (£79/£149/£299/£499)
- **BdaLeadController**: incentive calculation keyed by `planName|currency`, correctly applies GBP base prices instead of always falling back to USD

## Test plan
- [ ] BDA Incentive Settings loads with GBP rows pre-populated at £79/£149/£299/£499
- [ ] Saving GBP configs persists and reloads correctly
- [ ] Incentive calculation for a GBP payment uses GBP base price (prorated correctly)
- [ ] Existing USD and CAD rows unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)